### PR TITLE
Improved Display method

### DIFF
--- a/src/modules/DOF/src/DOF_Method.F90
+++ b/src/modules/DOF/src/DOF_Method.F90
@@ -40,8 +40,10 @@ PRIVATE
 !
 ! This subroutine initiate [[DOF_]] object
 !
-!- If the size of all physical variables are equal then set tNodes = [tNodes] otherwise we need to provide size of each dof
-!- For a scalar physical variable such as pressure and temperature, `spaceCompo` is set to -1.
+!- If the size of all physical variables are equal then set
+! tNodes = [tNodes] otherwise we need to provide size of each dof
+!- For a scalar physical variable such as pressure and temperature,
+! `spaceCompo` is set to -1.
 !- For a time independent physical variable `TimeCompo` is set to 1.
 !- The size of `Names`, `SpaceCompo`, `TimeCompo` should be same
 !
@@ -53,9 +55,29 @@ PRIVATE
 !### Usage
 !
 !```fortran
-!	type( dof_ ) :: obj
-! call initiate( obj, tNodes = [10], Names = ['x', 'y'], &
-!   & SpaceCompo = [3,3], TimeCompo = [1,1], StorageFMT = FMT_Nodes )
+! PROGRAM main
+! USE easifemBase
+! IMPLICIT NONE
+!
+! ! [[DOF_]]
+!
+! TYPE( DOF_ ) :: obj
+!
+! ! #DOF_/Initiate
+!
+! CALL Initiate( obj, tNodes=[10], names=["U"], spaceCompo=[3],  &
+!   & timeCompo=[1], storageFMT = FMT_DOF )
+!
+! CALL Display( .tDOF. obj, "tDOF : " )
+!
+! ! #DOF_/Display
+!
+! CALL Display( obj .tDOF. "U", "tDOF of U : " )
+!
+! ! #DOF_/DeallocateData
+!
+! CALL DeallocateData( obj )
+! END PROGRAM main
 !```
 
 INTERFACE
@@ -65,14 +87,14 @@ MODULE PURE SUBROUTINE dof_initiate1( obj, tNodes, Names, SpaceCompo, &
     !! degree of freedom object
   INTEGER( I4B ), INTENT( IN ) :: tNodes( : )
     !! number of nodes for each physical variable
+  CHARACTER( LEN = 1 ), INTENT( IN ) :: Names( : )
+    !! Names of each physical variable
   INTEGER( I4B ), INTENT( IN ) :: SpaceCompo( : )
     !! Space component of each physical variable
   INTEGER( I4B ), INTENT( IN ) :: TimeCompo( : )
     !! Time component of each physical variable
   INTEGER( I4B ), INTENT( IN ) :: StorageFMT
     !! Storage format `FMT_DOF`, `FMT_Nodes`
-  CHARACTER( LEN = 1 ), INTENT( IN ) :: Names( : )
-    !! Names of each physical variable
 END SUBROUTINE dof_initiate1
 END INTERFACE
 
@@ -86,20 +108,38 @@ END INTERFACE
 !
 !# Introduction
 !
-! This subroutine initiate a fortran vector of real using the information stored inside [[DOF_]] object.
-!
+! This subroutine initiates a fortran vector (rank-1 fortran array ) of
+! real using the information stored inside [[DOF_]] object. This subroutine
+! gets the size of array from the [[DOF_]] object and then reallocates
+! `Val` and set its all values to zero.
 !
 !### Usage
 !
 !```fortran
-! !... code above ...!
-! ! Initiate the [[DOF_]] object.
-!
-! CALL initiate( obj=obj%dof, tNodes=tNodes, names=names_char, &
-!   & spaceCompo=spaceCompo, timeCompo=timeCompo, storageFMT=storageFMT )
-! ! Initiate [[RealVector_]]
-!
-! CALL initiate( val=obj%realVec, obj=obj%dof )
+! PROGRAM main
+! ! USE easifemBase
+! IMPLICIT NONE
+! !
+! ! [[DOF_]]
+! !
+! TYPE( DOF_ ) :: obj
+! REAL( DFP ), ALLOCATABLE :: val( : )
+! !
+! ! #DOF_/Initiate
+! !
+! CALL Initiate( obj, tNodes=[10], names=["U"], spaceCompo=[3],  &
+!   & timeCompo=[1], storageFMT = FMT_DOF )
+! !
+! ! #DOF_/Initiate
+! !
+! CALL Initiate( Val=val, obj=obj )
+! !
+! CALL Display( Val, "CALL Initiate( Val=val, obj=obj ) : " )
+! !
+! ! #DOF_/DeallocateData
+! !
+! CALL DeallocateData( obj )
+! END PROGRAM main
 !```
 
 INTERFACE
@@ -122,19 +162,37 @@ END INTERFACE
 !# Introduction
 !
 ! This subroutine initiate [[RealVector_]] using the information stored inside
-! [[dof_]] object
+! [[dof_]] object. It gets the information of total size of [[RealVector_]]
+! from [[DOF_]] and call [[RealVector_Method:Initiate]] routine.
+! All values of [[RealVector_]] is set to zero.
 !
-!### Usage
+!## Usage
 !
 !```fortran
-! !... code above ...!
-! ! Initiate the [[DOF_]] object.
+! PROGRAM main
+! USE easifemBase
+! IMPLICIT NONE
 !
-! CALL initiate( obj=obj%dof, tNodes=tNodes, names=names_char, &
-!   & spaceCompo=spaceCompo, timeCompo=timeCompo, storageFMT=storageFMT )
-! ! Initiate [[RealVector_]]
+! ! [[DOF_]], [[RealVector_]]
 !
-! CALL initiate( val=obj%realVec, obj=obj%dof )
+! TYPE( DOF_ ) :: obj
+! TYPE(RealVector_) :: val
+!
+! ! #DOF_/Initiate
+!
+! CALL Initiate( obj, tNodes=[10], names=["U"], spaceCompo=[3],  &
+!   & timeCompo=[1], storageFMT = FMT_DOF )
+!
+! ! #DOF_/Initiate
+!
+! CALL Initiate( Val=val, obj=obj )
+!
+! CALL Display( Val, "CALL Initiate( Val=val, obj=obj ) : " )
+!
+! ! #DOF_/DeallocateData
+!
+! CALL DeallocateData( obj )
+! END PROGRAM main
 !```
 
 INTERFACE
@@ -148,14 +206,48 @@ END INTERFACE
 !                                                       Initiate@Constructor
 !----------------------------------------------------------------------------
 
-INTERFACE
-!! Initiate a vector of [[realvector_]] from [[dof_]] object
-
-!> authors: Dr. Vikas Sharma
+!> authors: Vikas Sharma, Ph. D.
+! date: 10 Oct, 2021
+! summary: Initiate a vector of [[realvector_]] from [[dof_]] object
 !
-! This subroutine initiate a vector of [[realvector_]] object
-! Each entry Val( idof ) denotes degree of freedom `idof`
+!# Introduction
+!
+! This subroutine initiates a vector of [[realvector_]] object.
+! The size of `Val` will be total number of degrees of freedom inside
+! the [[DOF_]] object. Therefore, each `Val( idof )` denotes the
+! nodal vector of correrponding to a degree of freedom number `idof`
+!
+!
+!## Usage
+!
+!```fortran
+! PROGRAM main
+! USE easifemBase
+! IMPLICIT NONE
+! !
+! ! [[DOF_]], [[RealVector_]]
+! !
+! TYPE( DOF_ ) :: obj
+! TYPE(RealVector_), ALLOCATABLE :: val( : )
+! !
+! ! #DOF_/Initiate
+! !
+! CALL Initiate( obj, tNodes=[10], names=["U"], spaceCompo=[3],  &
+!   & timeCompo=[1], storageFMT = FMT_DOF )
+! !
+! ! #DOF_/Initiate
+! !
+! CALL Initiate( Val=val, obj=obj )
+! !
+! CALL Display( Val, "CALL Initiate( Val=val, obj=obj ) : " )
+! !
+! ! #DOF_/DeallocateData
+! !
+! CALL DeallocateData( obj )
+! END PROGRAM main
+!```
 
+INTERFACE
 MODULE PURE SUBROUTINE dof_initiate4( Val, obj )
   TYPE( RealVector_ ), ALLOCATABLE, INTENT( INOUT ) :: Val( : )
   CLASS( DOF_ ), INTENT( IN ) :: obj
@@ -166,14 +258,16 @@ END INTERFACE
 !                                                       Initiate@Constructor
 !----------------------------------------------------------------------------
 
-INTERFACE
-!! Initiate two fortran vectors using [[dof_]] object
-
-!> authors: Dr. Vikas Sharma
+!> authors: Vikas Sharma, Ph. D.
+! date: 10 Oct, 2021
+! summary: Initiate two fortran vectors using [[dof_]] object
 !
-! This subroutine initiate two fortran vectors using  the information
-! stored inside the [[dof_]] object
+!# Introduction
+!
+! This subroutine can initiate two fortran vectors (rank-1 fortran arrays)
+! using  the information stored inside the [[DOF_]] object
 
+INTERFACE
 MODULE PURE SUBROUTINE dof_initiate5( Val1, Val2, obj )
   REAL( DFP ), ALLOCATABLE, INTENT( INOUT) :: Val1( : ), Val2( : )
   CLASS( DOF_ ), INTENT( IN ) :: obj
@@ -187,6 +281,17 @@ END INTERFACE
 !> authors: Vikas Sharma, Ph. D.
 ! date: 25 July 2021
 ! summary: Initiate an instance of [[DOF_]] by copying other object
+!
+!# Introduction
+!
+! This routine copy obj2 into obj1. It also define an assignment operator
+!
+!
+!## Usage
+!
+!```fortran
+! obj1 = obj2
+!```
 
 INTERFACE
 MODULE PURE SUBROUTINE dof_initiate6( obj1, obj2 )
@@ -223,14 +328,44 @@ PUBLIC :: Initiate
 !                                                            DOF@Constructor
 !----------------------------------------------------------------------------
 
-INTERFACE
-!! Constructor for [[dof_]] object
-
-!> authors: Dr. Vikas Sharma
+!> authors: Vikas Sharma, Ph. D.
+! date: 10 oct 2021
+! summary: 	 Constructor for [[dof_]] object
 !
-! This function return instance of [[dof_]]
+!# Introduction
+!
+! This function return instance of [[DOF_]]
+! This function calls [[DOF_Method:DOF_Initiate1]] method
 ! for more see [[dof_]]
+!
+!
+!## Usage
+!
+!```fortran
+! PROGRAM main
+! USE easifemBase
+! IMPLICIT NONE
+! !
+! ! [[DOF_]]
+! !
+! TYPE( DOF_ ) :: obj
+! !
+! ! #DOF_/Initiate
+! !
+! obj = DOF( tNodes=[10], names=["U"], spaceCompo=[3],  &
+!   & timeCompo=[1], storageFMT = FMT_DOF )
+! !
+! ! #DOF_/Display
+! !
+! CALL Display( obj, "DOF() : " )
+! !
+! ! #DOF_/DeallocateData
+! !
+! CALL DeallocateData( obj )
+! END PROGRAM main
+!```
 
+INTERFACE
 MODULE PURE FUNCTION dof_Constructor1( tNodes, Names, SpaceCompo, TimeCompo, &
   & StorageFMT ) RESULT( obj )
   TYPE(DOF_) :: obj
@@ -251,14 +386,43 @@ PUBLIC :: DOF
 !                                                     DOF_Pointer@Constructor
 !----------------------------------------------------------------------------
 
-INTERFACE
-!! Constructor for [[dof_]] object
-
-!> authors: Dr. Vikas Sharma
+!> authors: Vikas Sharma, Ph. D.
+! date: 10 Oct, 2021
+! summary: Returns pointer to newly created [[dof_]] object
+!
+!# Introduction
 !
 ! This function returns the pointer to instance of [[dof_]] object
 ! for more see [[dof_]]
+!
+!
+!## Usage
+!
+!```fortran
+! PROGRAM main
+! USE easifemBase
+! IMPLICIT NONE
+! !
+! ! [[DOF_]]
+! !
+! TYPE( DOF_ ), POINTER :: obj
+! !
+! ! #DOF_/Initiate
+! !
+! obj => DOF_POINTER( tNodes=[10], names=["U"], spaceCompo=[3],  &
+!   & timeCompo=[1], storageFMT = FMT_DOF )
+! !
+! ! #DOF_/Display
+! !
+! CALL Display( obj, "DOF() : " )
+! !
+! ! #DOF_/DeallocateData
+! !
+! CALL DeallocateData( obj )
+! END PROGRAM main
+!```
 
+INTERFACE
 MODULE FUNCTION dof_Constructor_1( tNodes, Names, SpaceCompo, TimeCompo, &
   & StorageFMT ) RESULT( obj )
   CLASS(DOF_), POINTER :: obj
@@ -287,13 +451,15 @@ PUBLIC :: DOF_Pointer
 !                                                 DeallocateData@Constructor
 !----------------------------------------------------------------------------
 
-INTERFACE
-!! Deallocate data in [[dof_]]
-
-!> authors: Dr. Vikas Sharma
+!> authors: Vikas Sharma, Ph. D.
+! date: Oct 10, 2021
+! summary: Deallocate data in [[dof_]]
 !
-! This subroutine deallocates the data in [[dof_]] object
+!# Introduction
+!
+! This subroutine deallocates the data in [[DOF_]] object
 
+INTERFACE
 MODULE PURE SUBROUTINE dof_DeallocateData( obj )
   CLASS(DOF_), INTENT( INOUT ) :: obj
 END SUBROUTINE dof_DeallocateData
@@ -307,7 +473,7 @@ END INTERFACE DeallocateData
 PUBLIC :: DeallocateData
 
 !----------------------------------------------------------------------------
-!                                                                Display@IO
+!                                                         Display@IOMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -323,12 +489,43 @@ END SUBROUTINE dof_Display1
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                                Display@IO
+!                                                          Display@IOMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
 ! date: 29 June 2021
 ! summary: Display content of fortran vec with [[DOF_]] object info
+!
+!
+!## Usage
+!
+!```fortran
+! PROGRAM main
+! USE easifemBase
+! IMPLICIT NONE
+! !
+! ! [[DOF_]]
+! !
+! TYPE( DOF_ ) :: obj
+! REAL( DFP ), ALLOCATABLE :: val( : )
+! !
+! ! #DOF_/Initiate
+! !
+! CALL Initiate( obj, tNodes=[10], names=["U"], spaceCompo=[3],  &
+!   & timeCompo=[1], storageFMT = FMT_DOF )
+! !
+! ! #DOF_/Initiate
+! !
+! CALL Initiate( Val=val, obj=obj )
+! val(1:10) = 1; val(11:20)=2; val(21:)=3
+! !
+! CALL Display( Val, obj, "CALL Initiate( Val=val, obj=obj ) : " )
+! !
+! ! #DOF_/DeallocateData
+! !
+! CALL DeallocateData( obj )
+! END PROGRAM main
+!```
 
 INTERFACE
 MODULE SUBROUTINE dof_Display2( Vec, obj, msg, unitno )
@@ -340,7 +537,7 @@ END SUBROUTINE dof_Display2
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                                Display@IO
+!                                                         Display@IOMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -369,7 +566,7 @@ PUBLIC :: Display
 
 !> authors: Vikas Sharma, Ph. D.
 ! date: 26 June 2021
-! summary: This function returns the total length of the vector which stores the dof stored inside `obj`.
+! summary: Returns the total length of the vector
 
 INTERFACE
   MODULE PURE FUNCTION dof_tNodes1( obj ) RESULT( Ans )
@@ -387,6 +584,7 @@ END INTERFACE
 ! summary: This function returns the total number of nodes
 !
 !# Introduction
+!
 ! This function returns the total number of nodes for a given degree of
 ! freedom number
 ! idof should be lesser than the total degree of freedom
@@ -435,7 +633,8 @@ END INTERFACE
 ! summary: This subroutine returns the total number of degrees of freedom
 !
 !# Introduction
-! This function returns the total number of degrees of freedom in a physical variable.
+! This function returns the total number of degrees of freedom in a
+! physical variable.
 ! The physical variable is specified by using its name.
 
 INTERFACE
@@ -455,7 +654,8 @@ END INTERFACE
 ! summary: This subroutine returns the total number of degrees of freedom
 !
 !# Introduction
-! This function returns the total number of degrees of freedom in a physical variable.
+! This function returns the total number of degrees of freedom in a
+! physical variable.
 ! The physical variable is specified by using its name.
 
 INTERFACE
@@ -479,18 +679,54 @@ PUBLIC :: OPERATOR( .tDOF. )
 !> authors: Vikas Sharma, Ph. D.
 ! date: 24 July 2021
 ! summary: This routine returns the location of node
+!
+!# Introduction
+!
+! This routine is like [[DOF_Method:getIndex]].
+! However, it does not return the index of all degrees of freedom of
+! a given physical variable. Instead, it returns the index of location of
+! degree of freedom number `idof` for a given node number `inode`.
+!
+! Note that `inode` should be lesser than the total number of nodes
+! defined for dof number `idof`.
+!
+! Also node that idofs are continuously numbered, so if there are two
+! or more physical variables, then idof of the second or later physical
+! variables will not start from 1.
 
 INTERFACE
-MODULE PURE FUNCTION dof_getNodeLoc( obj, inode, idof ) RESULT( Ans )
+MODULE PURE FUNCTION dof_getNodeLoc1( obj, inode, idof ) RESULT( Ans )
   TYPE( DOF_ ), INTENT( IN ) :: obj
   INTEGER( I4B ), INTENT( IN ) :: inode
   INTEGER( I4B ), INTENT( IN ) :: idof
   INTEGER( I4B ) :: ans
-END FUNCTION dof_getNodeLoc
+END FUNCTION dof_getNodeLoc1
+END INTERFACE
+
+!----------------------------------------------------------------------------
+!                                                       getNodeLoc@getMethod
+!----------------------------------------------------------------------------
+
+!> authors: Vikas Sharma, Ph. D.
+! date: 24 July 2021
+! summary: This routine returns the location of node
+!
+!# Introduction
+!
+! ans(1) : istart
+! ans(2) : iend
+! ans(3) : stride
+
+INTERFACE
+MODULE PURE FUNCTION dof_getNodeLoc2( obj, idof ) RESULT( Ans )
+  TYPE( DOF_ ), INTENT( IN ) :: obj
+  INTEGER( I4B ), INTENT( IN ) :: idof
+  INTEGER( I4B ) :: ans(3)
+END FUNCTION dof_getNodeLoc2
 END INTERFACE
 
 INTERFACE getNodeLoc
-  MODULE PROCEDURE dof_getNodeLoc
+  MODULE PROCEDURE dof_getNodeLoc1, dof_getNodeLoc2
 END INTERFACE getNodeLoc
 
 PUBLIC :: getNodeLoc
@@ -501,7 +737,7 @@ PUBLIC :: getNodeLoc
 
 !> authors: Vikas Sharma, Ph. D.
 ! date: 26 June 2021
-! summary: This subroutine returns the total number of names in dof object
+! summary: Returns the total number of names in dof object
 
 INTERFACE
 MODULE PURE FUNCTION dof_tNames( obj ) RESULT( Ans )
@@ -522,7 +758,7 @@ PUBLIC :: OPERATOR( .tNames. )
 
 !> authors: Vikas Sharma, Ph. D.
 ! date: 26 June 2021
-! summary: This function returns the name of all physical variables stored in obj
+! summary: Returns the name of all physical variables stored in obj
 
 INTERFACE
 MODULE PURE FUNCTION dof_names1( obj ) RESULT( Ans )
@@ -540,8 +776,10 @@ END INTERFACE
 ! summary: This function returns the name of a physical variable
 !
 !# Introduction
+!
 ! This function returns the name of a physical variable
-! The physical variable is given by its number ii, i.e., the first, second, third, and so on, physical variable.
+! The physical variable is given by its number ii, i.e., the first, second,
+! third, and so on, physical variable.
 
 INTERFACE
 MODULE PURE FUNCTION dof_names2( obj, ii ) RESULT( Ans )
@@ -582,7 +820,25 @@ END INTERFACE
 ! summary: Returns the indices for node number `nodeNum`
 !
 !# Introduction
-! This function returns the indices of a given node number. This indices can be used for getting all the dof defined on that nodeNum. The returned indiced can be used to extract values from the [[RealVector_]] or fortran vector of real numbers.
+!
+! - This function returns a vector of integers (indices) for a
+! a given node number.
+! - The size of these indices is equal to the total number of DOF in obj
+! - The returned indices represents the degrees of freedom defined on
+! each node.
+! - It is user's responsibility to ensure that for every physical variable
+! the `nodeNumber` is lesser than the total number of
+! nodes defined for that physical variable.
+! - The returned indices can be used for getting the dof (all dof)
+! defined on the nodeNum.
+! - The returned indiced can be used to extract values from an instance of
+! [[RealVector_]] or fortran vector of real numbers.
+!
+!@note
+! 	The size of returned vector `ans` will be the total number of
+! degrees of freedom in the [[DOF_]] object
+!@endnote
+!
 
 INTERFACE
 MODULE PURE FUNCTION dof_getIndex1( obj, nodeNum ) RESULT( Ans )
@@ -601,7 +857,21 @@ END INTERFACE
 ! summary: Returns the indices for node number `nodeNum`
 !
 !# Introduction
-! This function returns the indices of a given node number. This indices can be used for getting all the dof defined on that nodeNum. The returned indiced can be used to extract values from the [[RealVector_]] or fortran vector of real numbers.
+!
+! - This function returns a vector of integers (indices) for a
+! a given node number and a given physical Variable.
+! - The physical variable is defined by an `iVar`
+! - The size of these indices is equal to the total number of DOF
+! defined for the `iVar` physical variable.
+! - The returned indices represents the degrees of freedom of
+! physical variable `ivar` defined on each node.
+! - It is user's responsibility to ensure that for the selected physical var
+! the `nodeNumber` is lesser than the total number of
+! nodes defined for that physical variable.
+! - The returned indices can be used for getting the dof (all dof)
+! defined on the nodeNum for the given physical variable.
+! - The returned indices can be used to extract values from an instance of
+! [[RealVector_]] or fortran vector of real numbers.
 
 INTERFACE
 MODULE PURE FUNCTION dof_getIndex2( obj, nodeNum, iVar ) RESULT( Ans )
@@ -621,7 +891,22 @@ END INTERFACE
 ! summary: Returns the indices for node number `nodeNum`
 !
 !# Introduction
-! This function returns the indices of a given node number. This indices can be used for getting all the dof defined on that nodeNum. The returned indiced can be used to extract values from the [[RealVector_]] or fortran vector of real numbers.
+!
+! - This function returns a vector of integers (indices) for a
+! a given node number and a given physical Variable.
+! - The physical variable is defined by an `varName`
+! - The size of these indices is equal to the total number of DOF
+! defined for the `varName` physical variable.
+! - The returned indices represents the degrees of freedom of
+! physical variable `varName` defined on each node.
+! - It is user's responsibility to ensure that for the selected physical var
+! the `nodeNumber` is lesser than the total number of
+! nodes defined for that physical variable.
+! - The returned indices can be used for getting the dof (all dof)
+! defined on the nodeNum for the given physical variable.
+! - The returned indices can be used to extract values from an instance of
+! [[RealVector_]] or fortran vector of real numbers.
+
 
 INTERFACE
 MODULE PURE FUNCTION dof_getIndex3( obj, nodeNum, varName ) RESULT( Ans )
@@ -641,7 +926,20 @@ END INTERFACE
 ! summary: Returns the indices for node number `nodeNum`
 !
 !# Introduction
-! This function returns the indices of a given node number. This indices can be used for getting all the dof defined on that nodeNum. The returned indiced can be used to extract values from the [[RealVector_]] or fortran vector of real numbers.
+!
+! - This function returns a vector of integers (indices) for a
+! given list of node number.
+! - The size of these indices is equal to the total number of DOF in obj
+! times the size of nodeNum(:)
+! - The returned indices represents the degrees of freedom defined on
+! each nodes.
+! - It is user's responsibility to ensure that for every physical variable
+! the `nodeNumber` is lesser than the total number of
+! nodes defined for that physical variable.
+! - The returned indices can be used for getting the dof (all dof)
+! defined on the nodeNum.
+! - The returned indiced can be used to extract values from an instance of
+! [[RealVector_]] or fortran vector of real numbers.
 
 INTERFACE
 MODULE PURE FUNCTION dof_getIndex4( obj, nodeNum ) RESULT( Ans )
@@ -660,7 +958,21 @@ END INTERFACE
 ! summary: Returns the indices for node number `nodeNum`
 !
 !# Introduction
-! This function returns the indices of a given node number. This indices can be used for getting all the dof defined on that nodeNum. The returned indiced can be used to extract values from the [[RealVector_]] or fortran vector of real numbers.
+!
+! - This function returns a vector of integers (indices) for a
+! a given node number and a given physical Variable.
+! - The physical variable is defined by an `iVar`
+! - The size of these indices is equal to the total number of DOF
+! defined for the `iVar` physical variable.
+! - The returned indices represents the degrees of freedom of
+! physical variable `ivar` defined on each node.
+! - It is user's responsibility to ensure that for the selected physical var
+! the `nodeNumber` is lesser than the total number of
+! nodes defined for that physical variable.
+! - The returned indices can be used for getting the dof (all dof)
+! defined on the nodeNum for the given physical variable.
+! - The returned indices can be used to extract values from an instance of
+! [[RealVector_]] or fortran vector of real numbers.
 
 INTERFACE
 MODULE PURE FUNCTION dof_getIndex5( obj, nodeNum, iVar ) RESULT( Ans )
@@ -680,7 +992,21 @@ END INTERFACE
 ! summary: Returns the indices for node number `nodeNum`
 !
 !# Introduction
-! This function returns the indices of a given node number. This indices can be used for getting all the dof defined on that nodeNum. The returned indiced can be used to extract values from the [[RealVector_]] or fortran vector of real numbers.
+!
+! - This function returns a vector of integers (indices) for a
+! a given node number and a given physical Variable.
+! - The physical variable is defined by an `varName`
+! - The size of these indices is equal to the total number of DOF
+! defined for the `varName` physical variable.
+! - The returned indices represents the degrees of freedom of
+! physical variable `varName` defined on each node.
+! - It is user's responsibility to ensure that for the selected physical var
+! the `nodeNumber` is lesser than the total number of
+! nodes defined for that physical variable.
+! - The returned indices can be used for getting the dof (all dof)
+! defined on the nodeNum for the given physical variable.
+! - The returned indices can be used to extract values from an instance of
+! [[RealVector_]] or fortran vector of real numbers.
 
 INTERFACE
 MODULE PURE FUNCTION dof_getIndex6( obj, nodeNum, varName ) RESULT( Ans )

--- a/src/modules/Display/src/Display_Mat2.inc
+++ b/src/modules/Display/src/Display_Mat2.inc
@@ -18,11 +18,16 @@
 CHARACTER( LEN = * ), INTENT( IN ) :: msg
 INTEGER( I4B ), INTENT( IN ), OPTIONAL :: unitNo
 LOGICAL( LGT ), INTENT( IN ), OPTIONAL :: full
+CHARACTER( LEN = * ), OPTIONAL, INTENT( IN ) :: advance
 !   Define internal variables
 INTEGER( I4B ) :: I
 CALL setDefaultSettings
 IF( PRESENT( unitNo ) ) THEN; I = unitNo; ELSE; I = stdout; END IF
+#ifdef COLOR_DISP
 CALL DISP( &
   & title = TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
   & style=COLOR_STYLE)), &
-  & x= val, unit = I )
+  & x= val, unit = I, advance=advance )
+#else
+CALL DISP( title = msg, x= val, unit = I, advance=advance )
+#endif

--- a/src/modules/Display/src/Display_Mat3.inc
+++ b/src/modules/Display/src/Display_Mat3.inc
@@ -18,10 +18,11 @@
 CHARACTER( LEN = * ), INTENT( IN ) :: msg
 INTEGER( I4B ), INTENT( IN ), OPTIONAL :: unitNo
 LOGICAL( LGT ), OPTIONAL, INTENT( IN ) :: full
+CHARACTER( LEN = * ), OPTIONAL, INTENT( IN ) :: advance
 !   Define internal variables
 INTEGER( I4B ) :: J
 DO J = 1, SIZE( Val, 3 )
   CALL Display( val=Val( :, :, J ), &
     & msg=TRIM( msg ) //"( :, :, "//TRIM( Int2Str( J ) ) // " ) = ", &
-    & unitNo=unitNo, full=full )
+    & unitNo=unitNo, full=full, advance=advance )
 END DO

--- a/src/modules/Display/src/Display_Mat4.inc
+++ b/src/modules/Display/src/Display_Mat4.inc
@@ -18,6 +18,7 @@
 CHARACTER( LEN = * ), INTENT( IN ) :: msg
 INTEGER( I4B ), INTENT( IN ), OPTIONAL :: unitNo
 LOGICAL( LGT ), OPTIONAL, INTENT( IN ) :: full
+CHARACTER( LEN = * ), OPTIONAL, INTENT( IN ) :: advance
 ! Define internal variables
 INTEGER( I4B ) :: J, K
 DO K = 1, SIZE( Val, 4 )
@@ -29,6 +30,6 @@ DO K = 1, SIZE( Val, 4 )
     & // ", " &
     & // TRIM( Int2Str( K ) ) &
     & // " ) = " &
-    & , unitNo=unitNo, full=full )
+    & , unitNo=unitNo, full=full, advance=advance )
   END DO
 END DO

--- a/src/modules/Display/src/Display_Method.F90
+++ b/src/modules/Display/src/Display_Method.F90
@@ -45,11 +45,11 @@ CHARACTER( LEN = * ), PARAMETER :: COLOR_STYLE = "BOLD_ON"
 TYPE( DISP_SETTINGS ), PUBLIC, PARAMETER :: &
   & DisplayProfileTerminal = DISP_SETTINGS(&
   & advance="YES", matsep=" ", orient="COL", style="UNDERLINE", &
-  & trim="AUTO", ZEROAS="." )
+  & trim="YES", ZEROAS="." )
 TYPE( DISP_SETTINGS ), PUBLIC, PARAMETER :: &
   & DisplayProfilePrint = DISP_SETTINGS(&
-  & advance="YES", matsep=" ", orient="COL", style="LEFT", &
-  & trim="AUTO", ZEROAS="" )
+  & advance="YES", matsep=" ", orient="COL", style="UNDERLINE", &
+  & trim="YES", ZEROAS="" )
 TYPE( DISP_SETTINGS ), PARAMETER :: DisplayProfileOriginal = DISP_SETTINGS()
 LOGICAL( LGT ), SAVE :: defaultSettingSet = .FALSE.
 
@@ -150,12 +150,13 @@ END SUBROUTINE setDisplayProfile
 ! CALL Display( msg="hello world", unitno=stdout )
 !```
 
-SUBROUTINE Display_Str( msg, unitno )
+SUBROUTINE Display_Str( msg, unitno, advance  )
   ! Dummt arguments
   CHARACTER( LEN = * ), INTENT( IN ) :: msg
   !! input message
   INTEGER( I4B ), OPTIONAL, INTENT( IN ) :: unitno
   !! unit no
+  LOGICAL( LGT ), OPTIONAL, INTENT( IN ) :: advance
   ! Internal variables
   INTEGER( I4B ) :: i
   CALL setDefaultSettings
@@ -164,10 +165,38 @@ SUBROUTINE Display_Str( msg, unitno )
   ELSE
     i = stdout
   END IF
-  CALL disp( title="", &
-    & x=TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
-    & style=COLOR_STYLE)), &
-    & FMT = 'a', unit = i, style="left" )
+#ifdef COLOR_DISP
+  IF( PRESENT( advance ) ) THEN
+    IF( advance ) THEN
+      CALL DISP( title="", &
+        & x=TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
+        & style=COLOR_STYLE)), &
+        & FMT = 'a', unit = i, style="left", advance="YES" )
+    ELSE
+      CALL DISP( title="", &
+        & x=TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
+        & style=COLOR_STYLE)), &
+        & FMT = 'a', unit = i, style="left", advance="NO" )
+    END IF
+  ELSE
+    CALL DISP( title="", &
+        & x=TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
+        & style=COLOR_STYLE)), &
+        & FMT = 'a', unit = i, style="left" )
+  END IF
+#else
+  IF( PRESENT( advance ) ) THEN
+    IF( advance ) THEN
+      CALL DISP( title="", x=msg, FMT = 'a', unit = i, style="left",  &
+        & advance="YES" )
+    ELSE
+      CALL DISP( title="", x=msg, FMT = 'a', unit = i, style="left",  &
+        & advance="NO" )
+    END IF
+  ELSE
+    CALL DISP( title="", x=msg, FMT = 'a', unit = i, style="left" )
+  END IF
+#endif
 END SUBROUTINE Display_Str
 
 !----------------------------------------------------------------------------
@@ -187,12 +216,13 @@ END SUBROUTINE Display_Str
 !  CALL Display( val=" world!", msg="hello", stdout)
 !```
 
-SUBROUTINE Display_Str2( val, msg, unitno )
+SUBROUTINE Display_Str2( val, msg, unitno, advance )
   CHARACTER( LEN = * ), INTENT( IN ) :: val
   CHARACTER( LEN = * ), INTENT( IN ) :: msg
   INTEGER( I4B ), OPTIONAL, INTENT( IN ) :: unitno
+  LOGICAL( LGT ), OPTIONAL, INTENT(IN) :: advance
   ! internal variables
-  CALL Display( msg=TRIM(msg)//TRIM(val), unitNo=unitNo )
+  CALL Display( msg=TRIM(msg)//TRIM(val), unitNo=unitNo, advance=advance )
 END SUBROUTINE Display_Str2
 
 !----------------------------------------------------------------------------
@@ -213,7 +243,7 @@ END SUBROUTINE Display_Str2
 ! call display( val=1.0_DFP, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Real64( val, msg, unitNo )
+SUBROUTINE Display_Real64( val, msg, unitNo, advance )
   ! Define intent of dummy variables
   REAL( Real64 ), INTENT( IN ) :: val
 #include "./Display_Scalar.inc"
@@ -237,7 +267,7 @@ END SUBROUTINE Display_Real64
 ! call display( val=1.0_DFP, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Real32( val, msg, unitNo )
+SUBROUTINE Display_Real32( val, msg, unitNo, advance )
   ! Define intent of dummy variables
   REAL( Real32 ), INTENT( IN ) :: val
 #include "./Display_Scalar.inc"
@@ -261,7 +291,7 @@ END SUBROUTINE Display_Real32
 !  call display( val=1.0_I4B, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Int64( val, msg, unitNo )
+SUBROUTINE Display_Int64( val, msg, unitNo, advance )
   ! Define intent of dummy variables
   INTEGER( Int64 ), INTENT( IN ) :: val
 #include "./Display_Scalar.inc"
@@ -285,7 +315,7 @@ END SUBROUTINE Display_Int64
 !  call display( val=1.0_I4B, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Int32( val, msg, unitNo )
+SUBROUTINE Display_Int32( val, msg, unitNo, advance )
   ! Define intent of dummy variables
   INTEGER( Int32 ), INTENT( IN ) :: val
 #include "./Display_Scalar.inc"
@@ -309,7 +339,7 @@ END SUBROUTINE Display_Int32
 !  call display( val=1.0_I4B, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Int16( val, msg, unitNo )
+SUBROUTINE Display_Int16( val, msg, unitNo, advance )
   ! Define intent of dummy variables
   INTEGER( Int16 ), INTENT( IN ) :: val
 #include "./Display_Scalar.inc"
@@ -333,7 +363,7 @@ END SUBROUTINE Display_Int16
 !  call display( val=1.0_I4B, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Int8( val, msg, unitNo )
+SUBROUTINE Display_Int8( val, msg, unitNo, advance )
   ! Define intent of dummy variables
   INTEGER( Int8 ), INTENT( IN ) :: val
 #include "./Display_Scalar.inc"
@@ -357,7 +387,7 @@ END SUBROUTINE Display_Int8
 !  call display( val=.TRUE., msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Logical( val, msg, unitNo )
+SUBROUTINE Display_Logical( val, msg, unitNo, advance )
   ! Define intent of dummy variables
   LOGICAL( LGT ), INTENT( IN ) :: val
 #include "./Display_Scalar.inc"
@@ -384,7 +414,7 @@ END SUBROUTINE Display_Logical
 ! call display( val=vec, msg="var=", unitno=stdout, orient="col")
 !```
 
-SUBROUTINE Display_Vector_Real64( val, msg, unitNo, orient, full )
+SUBROUTINE Display_Vector_Real64( val, msg, unitNo, orient, full, advance )
   ! Define intent of dummy variables
   REAL( Real64 ), INTENT( IN ) :: val( : )
     !! vector of real numbers
@@ -412,7 +442,7 @@ END SUBROUTINE Display_Vector_Real64
 ! call display( val=vec, msg="var=", unitno=stdout, orient="col")
 !```
 
-SUBROUTINE Display_Vector_Real32( val, msg, unitNo, orient, full )
+SUBROUTINE Display_Vector_Real32( val, msg, unitNo, orient, full, advance )
   ! Define intent of dummy variables
   REAL( Real32 ), INTENT( IN ) :: val( : )
 #include "./Display_Vector.inc"
@@ -439,7 +469,7 @@ END SUBROUTINE Display_Vector_Real32
 ! call display( val=vec, msg="var=", unitno=stdout, orient="col")
 !```
 
-SUBROUTINE Display_Vector_Int32( val, msg, unitNo, orient, full )
+SUBROUTINE Display_Vector_Int32( val, msg, unitNo, orient, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int32 ), INTENT( IN ) :: val( : )
   !! vector of real numbers
@@ -467,7 +497,7 @@ END SUBROUTINE Display_Vector_Int32
 ! call display( val=vec, msg="var=", unitno=stdout, orient="col")
 !```
 
-SUBROUTINE Display_Vector_Int64( val, msg, unitNo, orient, full )
+SUBROUTINE Display_Vector_Int64( val, msg, unitNo, orient, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int64 ), INTENT( IN ) :: val( : )
   !! vector of real numbers
@@ -495,7 +525,7 @@ END SUBROUTINE Display_Vector_Int64
 ! call display( val=vec, msg="var=", unitno=stdout, orient="col")
 !```
 
-SUBROUTINE Display_Vector_Int16( val, msg, unitNo, orient, full )
+SUBROUTINE Display_Vector_Int16( val, msg, unitNo, orient, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int16 ), INTENT( IN ) :: val( : )
 #include "./Display_Vector.inc"
@@ -522,7 +552,7 @@ END SUBROUTINE Display_Vector_Int16
 ! call display( val=vec, msg="var=", unitno=stdout, orient="col")
 !```
 
-SUBROUTINE Display_Vector_Int8( val, msg, unitNo, orient, full )
+SUBROUTINE Display_Vector_Int8( val, msg, unitNo, orient, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int8 ), INTENT( IN ) :: val( : )
 #include "./Display_Vector.inc"
@@ -545,7 +575,7 @@ END SUBROUTINE Display_Vector_Int8
 ! call display( val=mat, msg="var=", unitno=stdout)
 ! ```
 
-SUBROUTINE Display_Mat2_Real64( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat2_Real64( Val, msg, unitNo, full, advance )
   !   Define intent of dummy variables
   REAL( Real64 ), DIMENSION( :, : ), INTENT( IN ) :: Val
 #include "./Display_Mat2.inc"
@@ -568,7 +598,7 @@ END SUBROUTINE Display_Mat2_Real64
 ! call display( val=mat, msg="var=", unitno=stdout)
 ! ```
 
-SUBROUTINE Display_Mat2_Real32( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat2_Real32( Val, msg, unitNo, full, advance )
   !   Define intent of dummy variables
   REAL( Real32 ), DIMENSION( :, : ), INTENT( IN ) :: Val
 #include "./Display_Mat2.inc"
@@ -590,7 +620,7 @@ END SUBROUTINE Display_Mat2_Real32
 ! call display( val=mat, msg="var=", unitno=stdout)
 ! ```
 
-SUBROUTINE Display_Mat2_Int64( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat2_Int64( Val, msg, unitNo, full, advance )
   !   Define intent of dummy variables
   INTEGER( Int64 ), DIMENSION( :, : ), INTENT( IN ) :: Val
 #include "./Display_Mat2.inc"
@@ -612,7 +642,7 @@ END SUBROUTINE Display_Mat2_Int64
 ! call display( val=mat, msg="var=", unitno=stdout)
 ! ```
 
-SUBROUTINE Display_Mat2_Int32( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat2_Int32( Val, msg, unitNo, full, advance )
   !   Define intent of dummy variables
   INTEGER( Int32 ), DIMENSION( :, : ), INTENT( IN ) :: Val
 #include "./Display_Mat2.inc"
@@ -634,7 +664,7 @@ END SUBROUTINE Display_Mat2_Int32
 ! call display( val=mat, msg="var=", unitno=stdout)
 ! ```
 
-SUBROUTINE Display_Mat2_Int16( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat2_Int16( Val, msg, unitNo, full, advance )
   !   Define intent of dummy variables
   INTEGER( Int16 ), DIMENSION( :, : ), INTENT( IN ) :: Val
 #include "./Display_Mat2.inc"
@@ -656,7 +686,7 @@ END SUBROUTINE Display_Mat2_Int16
 ! call display( val=mat, msg="var=", unitno=stdout)
 ! ```
 
-SUBROUTINE Display_Mat2_Int8( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat2_Int8( Val, msg, unitNo, full, advance )
   !   Define intent of dummy variables
   INTEGER( Int8 ), DIMENSION( :, : ), INTENT( IN ) :: Val
 #include "./Display_Mat2.inc"
@@ -681,7 +711,7 @@ END SUBROUTINE Display_Mat2_Int8
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat3_Real64( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat3_Real64( Val, msg, unitNo, full, advance  )
   !   Define intent of dummy variables
   REAL( Real64 ), INTENT( IN ) :: Val( :, :, : )
 #include "./Display_Mat3.inc"
@@ -706,7 +736,7 @@ END SUBROUTINE Display_Mat3_Real64
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat3_Real32( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat3_Real32( Val, msg, unitNo, full, advance  )
   !   Define intent of dummy variables
   REAL( Real32 ), INTENT( IN ) :: Val( :, :, : )
 #include "./Display_Mat3.inc"
@@ -731,7 +761,7 @@ END SUBROUTINE Display_Mat3_Real32
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat3_Int64( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat3_Int64( Val, msg, unitNo, full, advance  )
   !   Define intent of dummy variables
   INTEGER( Int64 ), INTENT( IN ) :: Val( :, :, : )
 #include "./Display_Mat3.inc"
@@ -756,7 +786,7 @@ END SUBROUTINE Display_Mat3_Int64
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat3_Int32( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat3_Int32( Val, msg, unitNo, full, advance  )
   !   Define intent of dummy variables
   INTEGER( Int32 ), INTENT( IN ) :: Val( :, :, : )
 #include "./Display_Mat3.inc"
@@ -782,7 +812,7 @@ END SUBROUTINE Display_Mat3_Int32
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat3_Int16( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat3_Int16( Val, msg, unitNo, full, advance  )
   !   Define intent of dummy variables
   INTEGER( Int16 ), INTENT( IN ) :: Val( :, :, : )
 #include "./Display_Mat3.inc"
@@ -808,7 +838,7 @@ END SUBROUTINE Display_Mat3_Int16
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat3_Int8( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat3_Int8( Val, msg, unitNo, full, advance  )
   !   Define intent of dummy variables
   INTEGER( Int8 ), INTENT( IN ) :: Val( :, :, : )
 #include "./Display_Mat3.inc"
@@ -834,7 +864,7 @@ END SUBROUTINE Display_Mat3_Int8
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat4_Real64( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat4_Real64( Val, msg, unitNo, full, advance )
   ! Define intent of dummy variables
   REAL( Real64 ), INTENT( IN ) :: Val( :, :, :, : )
 #include "./Display_Mat4.inc"
@@ -860,7 +890,7 @@ END SUBROUTINE Display_Mat4_Real64
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat4_Real32( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat4_Real32( Val, msg, unitNo, full, advance )
   ! Define intent of dummy variables
   REAL( Real32 ), INTENT( IN ) :: Val( :, :, :, : )
 #include "./Display_Mat4.inc"
@@ -886,7 +916,7 @@ END SUBROUTINE Display_Mat4_Real32
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat4_Int64( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat4_Int64( Val, msg, unitNo, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int64 ), INTENT( IN ) :: Val( :, :, :, : )
 #include "./Display_Mat4.inc"
@@ -912,7 +942,7 @@ END SUBROUTINE Display_Mat4_Int64
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat4_Int32( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat4_Int32( Val, msg, unitNo, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int32 ), INTENT( IN ) :: Val( :, :, :, : )
 #include "./Display_Mat4.inc"
@@ -938,7 +968,7 @@ END SUBROUTINE Display_Mat4_Int32
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat4_Int16( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat4_Int16( Val, msg, unitNo, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int16 ), INTENT( IN ) :: Val( :, :, :, : )
 #include "./Display_Mat4.inc"
@@ -964,7 +994,7 @@ END SUBROUTINE Display_Mat4_Int16
 ! call display( val=mat, msg="var=", unitno=stdout)
 !```
 
-SUBROUTINE Display_Mat4_Int8( Val, msg, unitNo, full )
+SUBROUTINE Display_Mat4_Int8( Val, msg, unitNo, full, advance )
   ! Define intent of dummy variables
   INTEGER( Int8 ), INTENT( IN ) :: Val( :, :, :, : )
 #include "./Display_Mat4.inc"

--- a/src/modules/Display/src/Display_Scalar.inc
+++ b/src/modules/Display/src/Display_Scalar.inc
@@ -17,11 +17,16 @@
 
 CHARACTER( LEN = * ), INTENT( IN ) :: msg
 INTEGER( I4B ), INTENT( IN ), OPTIONAL :: unitNo
+CHARACTER( LEN = * ), OPTIONAL, INTENT( IN ) :: advance
 ! Define internal variables
 INTEGER( I4B ) :: I
 CALL setDefaultSettings
 I = stdout; IF( PRESENT( unitNo ) ) I = unitNo
-CALL DISP( &
-  & title=TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
-  & style=COLOR_STYLE)), &
-  & x = val, unit = I, style = 'left' )
+#ifdef COLOR_DISP
+  CALL DISP( &
+    & title=TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
+    & style=COLOR_STYLE)), &
+    & x = val, unit = I, style = 'left', advance=advance )
+#else
+  CALL DISP( title=msg, x = val, unit = I, style = 'left', advance=advance )
+#endif

--- a/src/modules/Display/src/Display_Vector.inc
+++ b/src/modules/Display/src/Display_Vector.inc
@@ -25,6 +25,7 @@ CHARACTER( LEN = * ), OPTIONAL, INTENT( IN ) :: orient
 !! orient=col =>  columnwise printing
 LOGICAL( LGT ), INTENT( IN ), OPTIONAL :: full
 !! logical variable to print the whole vector
+CHARACTER( LEN = * ), OPTIONAL, INTENT( IN ) :: advance
 ! Define internal variables
 INTEGER( I4B ) :: I
 CHARACTER( LEN = 3 ) :: orient_
@@ -47,7 +48,11 @@ IF( PRESENT( orient ) ) THEN
 ELSE
   orient_ = "col"
 END IF
+#ifdef COLOR_DISP
 CALL DISP( &
   & title=TRIM(colorize( msg, color_fg=COLOR_FG, color_bg=COLOR_BG, &
   & style=COLOR_STYLE)), &
-  & x=val, unit = I, orient = orient_ )
+  & x=val, unit = I, orient = orient_, advance=advance )
+#else
+CALL DISP( title=msg, x=val, unit = I, orient = orient_, advance=advance )
+#endif

--- a/src/modules/RealVector/src/RealVector_Method.F90
+++ b/src/modules/RealVector/src/RealVector_Method.F90
@@ -188,10 +188,10 @@ PUBLIC :: DeallocateData
 !# Introduction This subroutine allocates the memeory for [[RealVector_]]
 !
 !@note
-! 	This subroutine is an alias for [[Allocate_Data]]
+! This subroutine is an alias for [[Allocate_Data]]
 !@endnote
 !
-! ```fortran
+!```fortran
 ! CALL Initiate(obj, 5)
 !```
 

--- a/src/submodules/DOF/CMakeLists.txt
+++ b/src/submodules/DOF/CMakeLists.txt
@@ -9,8 +9,8 @@
 SET(src_path "${CMAKE_CURRENT_LIST_DIR}/src/")
 TARGET_SOURCES(
   ${PROJECT_NAME} PRIVATE
-  ${src_path}/DOF_Method@Constructor.F90
-  ${src_path}/DOF_Method@IO.F90
-  ${src_path}/DOF_Method@setMethod.F90
-  ${src_path}/DOF_Method@getMethod.F90
+  ${src_path}/DOF_Method@ConstructorMethods.F90
+  ${src_path}/DOF_Method@IOMethods.F90
+  ${src_path}/DOF_Method@setMethods.F90
+  ${src_path}/DOF_Method@getMethods.F90
 )

--- a/src/submodules/DOF/src/DOF_Method@ConstructorMethods.F90
+++ b/src/submodules/DOF/src/DOF_Method@ConstructorMethods.F90
@@ -15,7 +15,7 @@
 ! along with this program.  If not, see <https: //www.gnu.org/licenses/>
 !
 
-SUBMODULE(DOF_Method) Constructor
+SUBMODULE(DOF_Method) ConstructorMethods
 USE BaseMethod
 IMPLICIT NONE
 CONTAINS
@@ -26,9 +26,8 @@ CONTAINS
 
 MODULE PROCEDURE dof_initiate1
   INTEGER( I4B ) :: n, i, k, j
-
+  !> main
   obj%StorageFMT = StorageFMT; n = SIZE( Names )
-
   CALL reallocate( obj%Map, n + 1, 6 )
   ASSOCIATE( Map => obj%Map )
     !
@@ -81,9 +80,7 @@ END PROCEDURE dof_initiate1
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE dof_initiate2
-  INTEGER( I4B ) :: tNodes
-  tNodes = .tNodes. obj
-  CALL Reallocate( Val, tNodes )
+  CALL Reallocate( Val, .tNodes. obj )
 END PROCEDURE dof_initiate2
 
 !----------------------------------------------------------------------------
@@ -91,9 +88,7 @@ END PROCEDURE dof_initiate2
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE dof_initiate3
-  INTEGER( I4B ) :: tNodes
-  tNodes = .tNodes. obj
-  CALL Reallocate( Val%Val, tNodes )
+  CALL Initiate( obj=val, tSize= (.tNodes. obj))
 END PROCEDURE dof_initiate3
 
 !----------------------------------------------------------------------------
@@ -101,14 +96,12 @@ END PROCEDURE dof_initiate3
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE dof_initiate4
-  INTEGER( I4B ) :: tDOF, i, n
+  INTEGER( I4B ) :: i
   INTEGER( I4B ), ALLOCATABLE :: tNodes( : )
-  !
+  ! main
   ASSOCIATE( Map => obj%Map )
-    tDOF = .tDOF. obj
-    ALLOCATE( tNodes( tDOF ) )
-    n = SIZE( Map, 1 )
-    DO i = 1, n-1
+    ALLOCATE( tNodes( .tDOF. obj ) )
+    DO i = 1, SIZE( Map, 1 ) - 1
       tNodes( Map( i, 5 ) : Map( i + 1, 5 ) - 1 ) = Map( i, 6 )
     END DO
     CALL Initiate( Val, tNodes )
@@ -164,5 +157,4 @@ MODULE PROCEDURE dof_DeallocateData
   IF( ALLOCATED( obj%ValMap ) ) DEALLOCATE( obj%ValMap )
 END PROCEDURE dof_DeallocateData
 
-
-END SUBMODULE Constructor
+END SUBMODULE ConstructorMethods

--- a/src/submodules/DOF/src/DOF_Method@IOMethods.F90
+++ b/src/submodules/DOF/src/DOF_Method@IOMethods.F90
@@ -19,7 +19,7 @@
 ! date: 	28 Feb 2021
 ! summary: 	This submodule contains IO method for [[DOF_]]
 
-SUBMODULE(DOF_Method) IO
+SUBMODULE(DOF_Method) IOMethods
 USE BaseMethod
 CONTAINS
 
@@ -33,13 +33,12 @@ MODULE PROCEDURE dof_Display1
   IF( LEN_TRIM( msg) .NE. 0 ) THEN
     CALL Display( "# "//TRIM( msg ), unitNo=unitNo )
   END IF
-
   IF( ALLOCATED( obj%Map ) ) THEN
     ASSOCIATE( Map => obj%Map, ValMap => obj%ValMap )
       n = SIZE( Map, 1 ) - 1
       CALL Display( n, "# Total Physical Variables :", unitNo=unitNo )
       DO j = 1, n
-        CALL Display("# Name : " // CHAR( Map( j, 1 ) ), unitNo=UnitNo )
+        CALL Display("# Name : " // CHAR( Map( j, 1 ) ), unitNo=unitNo )
         IF( Map( j, 2 ) .LT. 0 ) THEN
           CALL Display( "# Space Components : " // "Scalar", unitNo=unitNo)
         ELSE
@@ -66,43 +65,19 @@ END PROCEDURE dof_Display1
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE dof_display2
-  INTEGER( I4B ) :: I, j, n, tdof, idof, k
+  INTEGER( I4B ) :: jj, tnames, idof, a(3)
   !> main
-  tdof = .tdof. obj
-  IF( PRESENT( UnitNo ) ) THEN
-    I = UnitNo
-  ELSE
-    I = stdout
-  END IF
-  CALL Display( obj, 'Degree of freedom info=', Unitno = I )
-  n = SIZE( obj%Map, 1 ) - 1
-  SELECT CASE( obj%StorageFMT )
-  CASE( FMT_Nodes  )
-    DO j = 1, n
-      CALL BlankLines( UnitNo = I )
-      WRITE( I, "(4X, A)" ) "VAR : "//ACHAR( obj%Map( j, 1 )  )
-      DO idof = obj%Map( j, 5 ), obj%Map( j+1, 5 ) - 1
-        WRITE( I, "( 6X, A )", ADVANCE="NO" ) "--------------"
-      END DO
-      WRITE( I, "(A)", ADVANCE="YES" ) " "
-      DO idof = obj%Map( j, 5 ), obj%Map( j+1, 5 ) - 1
-        WRITE( I, "(6X, 4X, A, 4X )", ADVANCE="NO" ) "DOF-"//TRIM( INT2STR( idof ) )
-      END DO
-      WRITE( I, "(A)", ADVANCE="YES" ) " "
-      DO idof = obj%Map( j, 5 ), obj%Map( j+1, 5 ) - 1
-        WRITE( I, "( 6X, A )", ADVANCE="NO" ) "--------------"
-      END DO
-      WRITE( I, "(A)", ADVANCE="YES" ) " "
-      DO k = 1, obj%Map( j,  6)
-        DO idof = obj%Map( j, 5 ), obj%Map( j+1, 5 ) - 1
-          WRITE( I, "(I6, 2X, G10.2, 2X )", ADVANCE="NO" ) k, &
-            & Vec(  ( k - 1 ) * tdof + idof )
-        END DO
-        WRITE( I, "(A)", ADVANCE="YES" ) " "
-      END DO
+  CALL Display( obj, '# DOF data : ', unitNo = unitNo  )
+  tnames = .tNames. obj
+  DO jj = 1, tnames
+    CALL Display( ACHAR(obj%Map(jj,1)), "# VAR : ", unitNo)
+    DO idof = obj%Map( jj, 5 ), obj%Map( jj+1, 5 ) - 1
+      a = getNodeLOC( obj=obj, idof=idof )
+      CALL Display( Vec(a(1):a(2):a(3)),  &
+        & msg="DOF-"//TOSTRING( idof ), unitNo=unitNo, advance="NO" )
     END DO
-  CASE( FMT_DOF )
-  END SELECT
+    CALL Display( " ", unitNo=unitNo, advance=.TRUE. )
+  END DO
 END PROCEDURE dof_display2
 
 !----------------------------------------------------------------------------
@@ -114,4 +89,4 @@ MODULE PROCEDURE dof_display3
     CALL Display( vec=vec%val, obj=obj, msg=msg, unitNo=unitNo  )
   END IF
 END PROCEDURE dof_display3
-END SUBMODULE IO
+END SUBMODULE IOMethods

--- a/src/submodules/DOF/src/DOF_Method@getMethods.F90
+++ b/src/submodules/DOF/src/DOF_Method@getMethods.F90
@@ -15,7 +15,7 @@
 ! along with this program.  If not, see <https: //www.gnu.org/licenses/>
 !
 
-SUBMODULE(DOF_Method) GetMethod
+SUBMODULE(DOF_Method) GetMethods
 USE BaseMethod
 IMPLICIT NONE
 CONTAINS
@@ -63,7 +63,6 @@ END PROCEDURE dof_tdof1
 
 MODULE PROCEDURE dof_tdof2
   INTEGER( I4B ) :: i, k
-
   k = ICHAR( Name )
   IF( ALLOCATED( obj%Map ) ) THEN
     DO i = 1, SIZE( obj%Map, 1 ) - 1
@@ -88,6 +87,33 @@ MODULE PROCEDURE dof_tdof3
     Ans = 0
   END IF
 END PROCEDURE dof_tdof3
+
+!----------------------------------------------------------------------------
+!                                                               getNodeLoc
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE dof_getNodeLoc1
+  INTEGER( I4B ) :: tdof, tnodes
+  tdof = .tdof. obj
+  IF( obj%storageFMT .EQ. NODES_FMT ) THEN
+    ans = (inode-1)*tdof + idof
+  ELSE
+    tnodes = obj .tNodes. idof
+    ans = (idof-1)*tnodes + inode
+  END IF
+END PROCEDURE dof_getNodeLoc1
+
+!----------------------------------------------------------------------------
+!                                                               getNodeLoc
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE dof_getNodeLoc2
+  IF( obj%storageFMT .EQ. NODES_FMT ) THEN
+    ans = [idof, .tnodes. obj, .tdof. obj ]
+  ELSE
+    ans = [obj%valmap( idof ), obj%valmap(idof+1)-1, 1 ]
+  END IF
+END PROCEDURE dof_getNodeLoc2
 
 !----------------------------------------------------------------------------
 !                                                                     tNames
@@ -473,4 +499,4 @@ MODULE PROCEDURE dof_isNE
   ans = .NOT. ( dof_isEqual( obj1, obj2 ) )
 END PROCEDURE dof_isNE
 
-END SUBMODULE GetMethod
+END SUBMODULE GetMethods

--- a/src/submodules/DOF/src/DOF_Method@setMethods.F90
+++ b/src/submodules/DOF/src/DOF_Method@setMethods.F90
@@ -15,7 +15,7 @@
 ! along with this program.  If not, see <https: //www.gnu.org/licenses/>
 !
 
-SUBMODULE(DOF_Method) setMethod
+SUBMODULE(DOF_Method) setMethods
   !! This submodule defines the methods for setting/changing values in
   !! fortran real vector using [[dof_]] object
 
@@ -281,19 +281,4 @@ MODULE PROCEDURE dof_add2
   END ASSOCIATE
 END PROCEDURE dof_add2
 
-!----------------------------------------------------------------------------
-!                                                               getNodeLoc
-!----------------------------------------------------------------------------
-
-MODULE PROCEDURE dof_getNodeLoc
-  INTEGER( I4B ) :: tdof, tnodes
-  tdof = .tdof. obj
-  IF( obj%storageFMT .EQ. NODES_FMT ) THEN
-    ans = (inode-1)*tdof + idof
-  ELSE
-    tnodes = obj .tNodes. idof
-    ans = (idof-1)*tnodes + inode
-  END IF
-END PROCEDURE dof_getNodeLoc
-
-END SUBMODULE setMethod
+END SUBMODULE setMethods


### PR DESCRIPTION
This commit improves the Display function for DOF_ data type.

Now you can call 

```fortran
Dispaly(Vec, DOF, msg, unitNo)
```

For pretty printing

Test program

```fortran
PROGRAM main
USE easifemBase
IMPLICIT NONE
TYPE( DOF_ ) :: obj
REAL( DFP ), ALLOCATABLE :: val( : )
CALL Initiate( obj, tNodes=[10], names=["U"], spaceCompo=[3], &
    & timeCompo=[1], storageFMT = FMT_DOF )
CALL Initiate( Val=val, obj=obj )
val(1:10) = 1; val(11:20)=2; val(21:)=3
CALL Display( Val, obj, "CALL Initiate( Val=val, obj=obj ) : " )
CALL DeallocateData( obj )
END PROGRAM main
```

The out is given below

```fortran
# VAR :U
     DOF-1     DOF-2     DOF-3    
    -------   -------   -------   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000   
    1.00000   2.00000   3.00000
```
