### PR TITLE
OpenMP bug resolved

### DIFF
--- a/install.py
+++ b/install.py
@@ -42,104 +42,24 @@ else:
 
     cmake_def = ""
     user_query = False
-    if user_query:
-        ###################################
-        opt = getOption(
-            "CMAKE_GENERATOR", ["Unix Makefiles", "Ninja", "Ninja Multi-Config"]
-        )
-        if opt == " ":
-            # opt = '"Unix Makefiles"'
-            opt = '"Ninja"'
-        cmake_def += " -G " + opt
-        ###################################
-        opt = getOption("USE_PLPLOT", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_PLPLOT=" + opt
-        ###################################
-        opt = getOption("USE_BLAS95", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_BLAS95=" + opt
-        ###################################
-        opt = getOption("USE_LAPACK95", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_LAPACK95=" + opt
-        ###################################
-        opt = getOption("USE_ARPACK", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_ARPACK=" + opt
-        ###################################
-        opt = getOption("USE_PARPACK", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_PARPACK=" + opt
-        ###################################
-        opt = getOption("USE_OpenMP", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_OpenMP=" + opt
-        ###################################
-        opt = getOption("USE_FFTW", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_FFTW=" + opt
-        ###################################
-        opt = getOption("USE_METIS", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_METIS=" + opt
-        ###################################
-        opt = getOption("USE_SUPERLU", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_SUPERLU=" + opt
-        ###################################
-        opt = getOption("USE_LIS", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_LIS=" + opt
-        ###################################
-        opt = getOption("USE_GTK4", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_GTK4=" + opt
-        ###################################
-        opt = getOption("CMAKE_BUILD_TYPE", ["Release", "Debug"])
-        if opt == " ":
-            opt = "Release"
-        cmake_def += " -DCMAKE_BUILD_TYPE=" + opt
-        ###################################
-        opt = getOption("BUILD_SHARED_LIBS", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DBUILD_SHARED_LIBS=" + opt
-        ###################################
-        opt = getOption("CMAKE_INSTALL_PREFIX", ["${PREFIX}"])
-        if opt == " ":
-            opt = "${EASIFEM_BASE}"
-        cmake_def += " -DCMAKE_INSTALL_PREFIX=" + opt
-    else:
-        cmake_def = ""
-        cmake_def += ' -G "Ninja"'
-        cmake_def += " -D USE_OpenMP:BOOL=ON"
-        cmake_def += " -D CMAKE_BUILD_TYPE:STRING=Release"
-        cmake_def += " -D BUILD_SHARED_LIBS:BOOL=ON"
-        cmake_def += " -D USE_PLPLOT:BOOL=ON"
-        cmake_def += " -D CMAKE_INSTALL_PREFIX:PATH=${EASIFEM_BASE}"
-        cmake_def += " -D USE_BLAS95:BOOL=ON"
-        cmake_def += " -D USE_LAPACK95:BOOL=ON"
-        cmake_def += " -D USE_FFTW:BOOL=ON"
-        cmake_def += " -D USE_GTK:BOOL=ON"
-        cmake_def += " -D USE_ARPACK:BOOL=ON"
-        cmake_def += " -D USE_SUPERLU:BOOL=ON"
-        cmake_def += " -D USE_LIS:BOOL=ON"
-        cmake_def += " -D USE_PARPACK:BOOL=OFF"
-        cmake_def += " -D USE_METIS:BOOL=OFF"
-
-    cmake_def += " -D USE_Int32=ON -D USE_Real64=ON"
+    cmake_def = ""
+    cmake_def += ' -G "Ninja"'  # Unix Makefiles, Ninja, Ninja Multi-Config
+    cmake_def += " -D USE_OpenMP:BOOL=OFF"  # OFF
+    cmake_def += " -D CMAKE_BUILD_TYPE:STRING=Release"  # Debug
+    cmake_def += " -D BUILD_SHARED_LIBS:BOOL=ON"
+    cmake_def += " -D USE_PLPLOT:BOOL=ON"
+    cmake_def += " -D CMAKE_INSTALL_PREFIX:PATH=${EASIFEM_BASE}"
+    cmake_def += " -D USE_BLAS95:BOOL=ON"
+    cmake_def += " -D USE_LAPACK95:BOOL=ON"
+    cmake_def += " -D USE_FFTW:BOOL=ON"
+    cmake_def += " -D USE_GTK:BOOL=ON"
+    cmake_def += " -D USE_ARPACK:BOOL=ON"
+    cmake_def += " -D USE_SUPERLU:BOOL=ON"
+    cmake_def += " -D USE_LIS:BOOL=ON"
+    cmake_def += " -D USE_PARPACK:BOOL=OFF"
+    cmake_def += " -D USE_METIS:BOOL=OFF"
+    cmake_def += " -D USE_Int32:BOOL=ON"
+    cmake_def += " -D USE_Real64:BOOL=ON"
 
     print("CMAKE DEF : ", cmake_def)
 

--- a/package.py
+++ b/package.py
@@ -6,31 +6,6 @@
 import os
 import platform
 
-
-def installRequest(LIB):
-    while True:
-        choice = input(f"Do you want to Install {LIB} 'yes' or 'no' [Y/n]: ")
-        if choice == " ":
-            choice = "no"
-        else:
-            choice = choice.lower()
-        if choice in ["Y", "y", "ye", "yes"]:
-            return True
-        else:
-            return False
-
-
-def getOption(key, opt):
-    while True:
-        separator = ", "
-        return (
-            input(
-                f"select option for {key}, possible options are : {separator.join(opt)} : "
-            )
-            + " "
-        )
-
-
 print("Detecting OS type...")
 _os = platform.system()
 if _os == "Windows":
@@ -42,104 +17,24 @@ else:
 
     cmake_def = ""
     user_query = False
-    if user_query:
-        ###################################
-        opt = getOption(
-            "CMAKE_GENERATOR", ["Unix Makefiles", "Ninja", "Ninja Multi-Config"]
-        )
-        if opt == " ":
-            # opt = '"Unix Makefiles"'
-            opt = '"Ninja"'
-        cmake_def += " -G " + opt
-        ###################################
-        opt = getOption("USE_PLPLOT", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_PLPLOT=" + opt
-        ###################################
-        opt = getOption("USE_BLAS95", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_BLAS95=" + opt
-        ###################################
-        opt = getOption("USE_LAPACK95", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_LAPACK95=" + opt
-        ###################################
-        opt = getOption("USE_ARPACK", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_ARPACK=" + opt
-        ###################################
-        opt = getOption("USE_PARPACK", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_PARPACK=" + opt
-        ###################################
-        opt = getOption("USE_OpenMP", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_OpenMP=" + opt
-        ###################################
-        opt = getOption("USE_FFTW", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_FFTW=" + opt
-        ###################################
-        opt = getOption("USE_METIS", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_METIS=" + opt
-        ###################################
-        opt = getOption("USE_SUPERLU", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_SUPERLU=" + opt
-        ###################################
-        opt = getOption("USE_LIS", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_LIS=" + opt
-        ###################################
-        opt = getOption("USE_GTK4", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DUSE_GTK4=" + opt
-        ###################################
-        opt = getOption("CMAKE_BUILD_TYPE", ["Release", "Debug"])
-        if opt == " ":
-            opt = "Release"
-        cmake_def += " -DCMAKE_BUILD_TYPE=" + opt
-        ###################################
-        opt = getOption("BUILD_SHARED_LIBS", ["ON", "OFF"])
-        if opt == " ":
-            opt = "ON"
-        cmake_def += " -DBUILD_SHARED_LIBS=" + opt
-        ###################################
-        opt = getOption("CMAKE_INSTALL_PREFIX", ["${PREFIX}"])
-        if opt == " ":
-            opt = "${EASIFEM_BASE}"
-        cmake_def += " -DCMAKE_INSTALL_PREFIX=" + opt
-    else:
-        cmake_def = ""
-        cmake_def += ' -G "Ninja"'
-        cmake_def += " -D USE_OpenMP:BOOL=ON"
-        cmake_def += " -D CMAKE_BUILD_TYPE:STRING=Release"
-        cmake_def += " -D BUILD_SHARED_LIBS:BOOL=ON"
-        cmake_def += " -D USE_PLPLOT:BOOL=ON"
-        cmake_def += " -D CMAKE_INSTALL_PREFIX:PATH=${EASIFEM_BASE}"
-        cmake_def += " -D USE_BLAS95:BOOL=ON"
-        cmake_def += " -D USE_LAPACK95:BOOL=ON"
-        cmake_def += " -D USE_FFTW:BOOL=ON"
-        cmake_def += " -D USE_GTK:BOOL=ON"
-        cmake_def += " -D USE_ARPACK:BOOL=ON"
-        cmake_def += " -D USE_SUPERLU:BOOL=ON"
-        cmake_def += " -D USE_LIS:BOOL=ON"
-        cmake_def += " -D USE_PARPACK:BOOL=OFF"
-        cmake_def += " -D USE_METIS:BOOL=OFF"
-
-    cmake_def += " -D USE_Int32=ON -D USE_Real64=ON"
+    cmake_def = ""
+    cmake_def += ' -G "Ninja"'
+    cmake_def += " -D USE_OpenMP:BOOL=ON"
+    cmake_def += " -D CMAKE_BUILD_TYPE:STRING=Release"
+    cmake_def += " -D BUILD_SHARED_LIBS:BOOL=ON"
+    cmake_def += " -D USE_PLPLOT:BOOL=ON"
+    cmake_def += " -D CMAKE_INSTALL_PREFIX:PATH=${EASIFEM_BASE}"
+    cmake_def += " -D USE_BLAS95:BOOL=ON"
+    cmake_def += " -D USE_LAPACK95:BOOL=ON"
+    cmake_def += " -D USE_FFTW:BOOL=ON"
+    cmake_def += " -D USE_GTK:BOOL=ON"
+    cmake_def += " -D USE_ARPACK:BOOL=ON"
+    cmake_def += " -D USE_SUPERLU:BOOL=ON"
+    cmake_def += " -D USE_LIS:BOOL=ON"
+    cmake_def += " -D USE_PARPACK:BOOL=OFF"
+    cmake_def += " -D USE_METIS:BOOL=OFF"
+    cmake_def += " -D USE_Int32:BOOL=ON"
+    cmake_def += " -D USE_Real64:BOOL=ON"
 
     print("CMAKE DEF : ", cmake_def)
 

--- a/src/modules/BaseMethod/src/BaseMethod.F90
+++ b/src/modules/BaseMethod/src/BaseMethod.F90
@@ -64,6 +64,10 @@ USE EASIFEM_ARPACK
 USE FFTW3
 #endif
 
+#ifdef USE_METIS
+USE MetisInterface
+#endif
+
 USE String_Class
 USE String_Method
 USE PENF, ONLY: endianL, endianB, endian, byte_size, str_ascii, &
@@ -74,11 +78,6 @@ USE FACE
 USE FPL
 USE System_Method
 USE CInterface
-
-#ifdef USE_METIS
-USE MetisInterface
-#endif
-
 USE OpenMP_Method
 USE GlobalData
 USE Hashing32

--- a/src/modules/Polynomial/src/QuadrangleInterpolationUtility.F90
+++ b/src/modules/Polynomial/src/QuadrangleInterpolationUtility.F90
@@ -126,7 +126,7 @@ PUBLIC :: EquidistanceInPoint_Quadrangle
 !- The node numbering is according to Gmsh convention.
 
 INTERFACE
-  MODULE PURE FUNCTION EquidistancePoint_Quadrangle(order, xij) RESULT(ans)
+  MODULE RECURSIVE PURE FUNCTION EquidistancePoint_Quadrangle(order, xij) RESULT(ans)
     INTEGER(I4B), INTENT(IN) :: order
   !! order
     REAL(DFP), OPTIONAL, INTENT(IN) :: xij(:, :)

--- a/src/modules/Polynomial/src/RecursiveNodesUtility.F90
+++ b/src/modules/Polynomial/src/RecursiveNodesUtility.F90
@@ -46,7 +46,7 @@ INTERFACE
       !! barycentric coordinates, in xiJ format
       !! size(ans,1) = 2 corresponding to b0 and b1
       !! size(ans,2) total number of points
-    CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: domain
+    CHARACTER(*), OPTIONAL, INTENT(IN) :: domain
       !! unit (0,1)
       !! biunit (-1, 1)
       !! equilateral
@@ -81,7 +81,7 @@ INTERFACE
       !! barycentric coordinates, in xiJ format
       !! size(ans,1) = 3 corresponding to b0, b1, b2
       !! size(ans,2) total number of points
-    CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: domain
+    CHARACTER(*), OPTIONAL, INTENT(IN) :: domain
       !! unit
       !! Biunit
       !! Equilateral
@@ -116,7 +116,7 @@ INTERFACE
       !! barycentric coordinates, in xiJ format
       !! size(ans,1) = 4 corresponding to b0, b1, b2, b3
       !! size(ans,2) total number of points
-    CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: domain
+    CHARACTER(*), OPTIONAL, INTENT(IN) :: domain
       !! unit
       !! Biunit
       !! Equilateral
@@ -132,7 +132,7 @@ PUBLIC :: RecursiveNode3D
 INTERFACE
   MODULE PURE FUNCTION ToUnit(x, domain) RESULT(ans)
     REAL(DFP), INTENT(IN) :: x(:, :)
-    CHARACTER(LEN=*), INTENT(IN) :: domain
+    CHARACTER(*), INTENT(IN) :: domain
     REAL(DFP), ALLOCATABLE :: ans(:, :)
   END FUNCTION ToUnit
 END INTERFACE
@@ -144,7 +144,7 @@ END INTERFACE
 INTERFACE
   MODULE PURE FUNCTION FromUnit(x, domain) RESULT(ans)
     REAL(DFP), INTENT(IN) :: x(:, :)
-    CHARACTER(LEN=*), INTENT(IN) :: domain
+    CHARACTER(*), INTENT(IN) :: domain
     REAL(DFP), ALLOCATABLE :: ans(:, :)
   END FUNCTION FromUnit
 END INTERFACE
@@ -154,7 +154,7 @@ END INTERFACE
 !----------------------------------------------------------------------------
 
 INTERFACE
-  MODULE PURE SUBROUTINE Unit2Equilateral(d, x)
+  MODULE RECURSIVE PURE SUBROUTINE Unit2Equilateral(d, x)
     INTEGER(I4B), INTENT(IN) :: d
     REAL(DFP), INTENT(INOUT) :: x(:, :)
   END SUBROUTINE Unit2Equilateral
@@ -165,7 +165,7 @@ END INTERFACE
 !----------------------------------------------------------------------------
 
 INTERFACE
-  MODULE PURE SUBROUTINE Equilateral2Unit(d, x)
+  MODULE RECURSIVE PURE SUBROUTINE Equilateral2Unit(d, x)
     INTEGER(I4B), INTENT(IN) :: d
     REAL(DFP), INTENT(INOUT) :: x(:, :)
   END SUBROUTINE Equilateral2Unit
@@ -178,8 +178,8 @@ END INTERFACE
 INTERFACE
   MODULE PURE FUNCTION Coord_Map(x, from, to) RESULT(ans)
     REAL(DFP), INTENT(IN) :: x(:, :)
-    CHARACTER(LEN=*), INTENT(IN) :: from
-    CHARACTER(LEN=*), INTENT(IN) :: to
+    CHARACTER(*), INTENT(IN) :: from
+    CHARACTER(*), INTENT(IN) :: to
     REAL(DFP), ALLOCATABLE :: ans(:, :)
   END FUNCTION Coord_Map
 END INTERFACE

--- a/src/modules/Polynomial/src/TetrahedronInterpolationUtility.F90
+++ b/src/modules/Polynomial/src/TetrahedronInterpolationUtility.F90
@@ -126,7 +126,7 @@ PUBLIC :: EquidistanceInPoint_Tetrahedron
 !- The node numbering is according to Gmsh convention.
 
 INTERFACE
-  MODULE PURE FUNCTION EquidistancePoint_Tetrahedron(order, xij) RESULT(ans)
+  MODULE RECURSIVE PURE FUNCTION EquidistancePoint_Tetrahedron(order, xij) RESULT(ans)
     INTEGER(I4B), INTENT(IN) :: order
   !! order
     REAL(DFP), OPTIONAL, INTENT(IN) :: xij(:, :)
@@ -155,7 +155,7 @@ INTERFACE
     !! order of element
     INTEGER(I4B), INTENT(IN) :: ipType
     !! interpolation type
-    CHARACTER(LEN=*), INTENT(IN) :: layout
+    CHARACTER(*), INTENT(IN) :: layout
     REAL(DFP), OPTIONAL, INTENT(IN) :: xij(3, 4)
     !! coordinates of vertices in $x_{iJ}$ format
     REAL(DFP), ALLOCATABLE :: nodecoord(:, :)

--- a/src/modules/Polynomial/src/TriangleInterpolationUtility.F90
+++ b/src/modules/Polynomial/src/TriangleInterpolationUtility.F90
@@ -125,7 +125,7 @@ PUBLIC :: EquidistanceInPoint_Triangle
 !- The node numbering is according to Gmsh convention, VEFC.
 
 INTERFACE
-  MODULE PURE FUNCTION EquidistancePoint_Triangle(order, xij) RESULT(ans)
+  MODULE RECURSIVE PURE FUNCTION EquidistancePoint_Triangle(order, xij) RESULT(ans)
     INTEGER(I4B), INTENT(IN) :: order
   !! order
     REAL(DFP), OPTIONAL, INTENT(IN) :: xij(:, :)

--- a/src/modules/Utility/src/BinomUtility.F90
+++ b/src/modules/Utility/src/BinomUtility.F90
@@ -43,12 +43,12 @@ PUBLIC :: Binom
 !```
 
 INTERFACE
-  MODULE PURE FUNCTION Real32_Binom_Int8(n, k, kind) RESULT(ans)
-    INTEGER(Int8), INTENT(IN) :: n
+  MODULE RECURSIVE PURE FUNCTION Real32_Binom_Int8(n, k, kind) RESULT(ans)
+    INTEGER(INT8), INTENT(IN) :: n
     !! n is integer, should be a positive number and greater or equal to k
-    INTEGER(Int8), INTENT(IN) :: k
-    REAL(Real32), INTENT(IN) :: kind
-    REAL(Real32) :: ans
+    INTEGER(INT8), INTENT(IN) :: k
+    REAL(REAL32), INTENT(IN) :: kind
+    REAL(REAL32) :: ans
   END FUNCTION Real32_Binom_Int8
 END INTERFACE
 
@@ -57,11 +57,11 @@ END INTERFACE
 !----------------------------------------------------------------------------
 
 INTERFACE
-  MODULE PURE FUNCTION Real32_Binom_Int16(n, k, kind) RESULT(ans)
-    INTEGER(Int16), INTENT(IN) :: n
-    INTEGER(Int16), INTENT(IN) :: k
-    REAL(Real32), INTENT(IN) :: kind
-    REAL(Real32) :: ans
+  MODULE RECURSIVE PURE FUNCTION Real32_Binom_Int16(n, k, kind) RESULT(ans)
+    INTEGER(INT16), INTENT(IN) :: n
+    INTEGER(INT16), INTENT(IN) :: k
+    REAL(REAL32), INTENT(IN) :: kind
+    REAL(REAL32) :: ans
   END FUNCTION Real32_Binom_Int16
 END INTERFACE
 
@@ -70,18 +70,18 @@ END INTERFACE
 !----------------------------------------------------------------------------
 
 INTERFACE
-  MODULE PURE FUNCTION Real32_Binom_Int32(n, k, kind) RESULT(ans)
-    INTEGER(Int32), INTENT(IN) :: n
-    INTEGER(Int32), INTENT(IN) :: k
-    REAL(Real32), INTENT(IN) :: kind
-    REAL(Real32) :: ans
+  MODULE RECURSIVE PURE FUNCTION Real32_Binom_Int32(n, k, kind) RESULT(ans)
+    INTEGER(INT32), INTENT(IN) :: n
+    INTEGER(INT32), INTENT(IN) :: k
+    REAL(REAL32), INTENT(IN) :: kind
+    REAL(REAL32) :: ans
   END FUNCTION Real32_Binom_Int32
   !!
-  MODULE PURE FUNCTION Real32_Binom_Int64(n, k, kind) RESULT(ans)
-    INTEGER(Int64), INTENT(IN) :: n
-    INTEGER(Int64), INTENT(IN) :: k
-    REAL(Real32), INTENT(IN) :: kind
-    REAL(Real32) :: ans
+  MODULE RECURSIVE PURE FUNCTION Real32_Binom_Int64(n, k, kind) RESULT(ans)
+    INTEGER(INT64), INTENT(IN) :: n
+    INTEGER(INT64), INTENT(IN) :: k
+    REAL(REAL32), INTENT(IN) :: kind
+    REAL(REAL32) :: ans
   END FUNCTION Real32_Binom_Int64
 END INTERFACE
 
@@ -95,32 +95,32 @@ END INTERFACE Binom
 !----------------------------------------------------------------------------
 
 INTERFACE
-  MODULE PURE FUNCTION Real64_Binom_Int8(n, k, kind) RESULT(ans)
-    INTEGER(Int8), INTENT(IN) :: n
-    INTEGER(Int8), INTENT(IN) :: k
-    REAL(Real64), INTENT(IN) :: kind
-    REAL(Real64) :: ans
+  MODULE RECURSIVE PURE FUNCTION Real64_Binom_Int8(n, k, kind) RESULT(ans)
+    INTEGER(INT8), INTENT(IN) :: n
+    INTEGER(INT8), INTENT(IN) :: k
+    REAL(REAL64), INTENT(IN) :: kind
+    REAL(REAL64) :: ans
   END FUNCTION Real64_Binom_Int8
   !!
-  MODULE PURE FUNCTION Real64_Binom_Int16(n, k, kind) RESULT(ans)
-    INTEGER(Int16), INTENT(IN) :: n
-    INTEGER(Int16), INTENT(IN) :: k
-    REAL(Real64), INTENT(IN) :: kind
-    REAL(Real64) :: ans
+  MODULE RECURSIVE PURE FUNCTION Real64_Binom_Int16(n, k, kind) RESULT(ans)
+    INTEGER(INT16), INTENT(IN) :: n
+    INTEGER(INT16), INTENT(IN) :: k
+    REAL(REAL64), INTENT(IN) :: kind
+    REAL(REAL64) :: ans
   END FUNCTION Real64_Binom_Int16
   !!
-  MODULE PURE FUNCTION Real64_Binom_Int32(n, k, kind) RESULT(ans)
-    INTEGER(Int32), INTENT(IN) :: n
-    INTEGER(Int32), INTENT(IN) :: k
-    REAL(Real64), INTENT(IN) :: kind
-    REAL(Real64) :: ans
+  MODULE RECURSIVE PURE FUNCTION Real64_Binom_Int32(n, k, kind) RESULT(ans)
+    INTEGER(INT32), INTENT(IN) :: n
+    INTEGER(INT32), INTENT(IN) :: k
+    REAL(REAL64), INTENT(IN) :: kind
+    REAL(REAL64) :: ans
   END FUNCTION Real64_Binom_Int32
   !!
-  MODULE PURE FUNCTION Real64_Binom_Int64(n, k, kind) RESULT(ans)
-    INTEGER(Int64), INTENT(IN) :: n
-    INTEGER(Int64), INTENT(IN) :: k
-    REAL(Real64), INTENT(IN) :: kind
-    REAL(Real64) :: ans
+  MODULE RECURSIVE PURE FUNCTION Real64_Binom_Int64(n, k, kind) RESULT(ans)
+    INTEGER(INT64), INTENT(IN) :: n
+    INTEGER(INT64), INTENT(IN) :: k
+    REAL(REAL64), INTENT(IN) :: kind
+    REAL(REAL64) :: ans
   END FUNCTION Real64_Binom_Int64
 END INTERFACE
 

--- a/src/modules/Utility/src/IntegerUtility.F90
+++ b/src/modules/Utility/src/IntegerUtility.F90
@@ -75,7 +75,7 @@ END INTERFACE Size
 ! summary:         Get Indices
 
 INTERFACE
-  MODULE PURE FUNCTION obj_GetMultiIndices1(n, d) RESULT(ans)
+  MODULE RECURSIVE PURE FUNCTION obj_GetMultiIndices1(n, d) RESULT(ans)
     INTEGER(I4B), INTENT(IN) :: n, d
     INTEGER(I4B), ALLOCATABLE :: ans(:, :)
   END FUNCTION obj_GetMultiIndices1
@@ -94,7 +94,7 @@ END INTERFACE GetMultiIndices
 ! summary:         Get Indices upto order n
 
 INTERFACE
-  MODULE PURE FUNCTION obj_GetMultiIndices2(n, d, upto) RESULT(ans)
+  MODULE RECURSIVE PURE FUNCTION obj_GetMultiIndices2(n, d, upto) RESULT(ans)
     INTEGER(I4B), INTENT(IN) :: n, d
     LOGICAL(LGT), INTENT(IN) :: upto
     INTEGER(I4B), ALLOCATABLE :: ans(:, :)
@@ -117,26 +117,26 @@ END INTERFACE GetMultiIndices
 INTERFACE
 
   MODULE PURE FUNCTION in_1a(a, b) RESULT(Ans)
-    INTEGER(Int8), INTENT(IN) :: a(:)
-    INTEGER(Int8), INTENT(IN) :: b(:)
+    INTEGER(INT8), INTENT(IN) :: a(:)
+    INTEGER(INT8), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_1a
 
   MODULE PURE FUNCTION in_1b(a, b) RESULT(Ans)
-    INTEGER(Int16), INTENT(IN) :: a(:)
-    INTEGER(Int16), INTENT(IN) :: b(:)
+    INTEGER(INT16), INTENT(IN) :: a(:)
+    INTEGER(INT16), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_1b
 
   MODULE PURE FUNCTION in_1c(a, b) RESULT(Ans)
-    INTEGER(Int32), INTENT(IN) :: a(:)
-    INTEGER(Int32), INTENT(IN) :: b(:)
+    INTEGER(INT32), INTENT(IN) :: a(:)
+    INTEGER(INT32), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_1c
 
   MODULE PURE FUNCTION in_1d(a, b) RESULT(Ans)
-    INTEGER(Int64), INTENT(IN) :: a(:)
-    INTEGER(Int64), INTENT(IN) :: b(:)
+    INTEGER(INT64), INTENT(IN) :: a(:)
+    INTEGER(INT64), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_1d
 
@@ -163,26 +163,26 @@ END INTERFACE OPERATOR(.in.)
 INTERFACE
 
   MODULE PURE FUNCTION isin_1a(a, b) RESULT(Ans)
-    INTEGER(Int8), INTENT(IN) :: a(:)
-    INTEGER(Int8), INTENT(IN) :: b(:)
+    INTEGER(INT8), INTENT(IN) :: a(:)
+    INTEGER(INT8), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans(SIZE(a))
   END FUNCTION isin_1a
 
   MODULE PURE FUNCTION isin_1b(a, b) RESULT(Ans)
-    INTEGER(Int16), INTENT(IN) :: a(:)
-    INTEGER(Int16), INTENT(IN) :: b(:)
+    INTEGER(INT16), INTENT(IN) :: a(:)
+    INTEGER(INT16), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans(SIZE(a))
   END FUNCTION isin_1b
 
   MODULE PURE FUNCTION isin_1c(a, b) RESULT(Ans)
-    INTEGER(Int32), INTENT(IN) :: a(:)
-    INTEGER(Int32), INTENT(IN) :: b(:)
+    INTEGER(INT32), INTENT(IN) :: a(:)
+    INTEGER(INT32), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans(SIZE(a))
   END FUNCTION isin_1c
 
   MODULE PURE FUNCTION isin_1d(a, b) RESULT(Ans)
-    INTEGER(Int64), INTENT(IN) :: a(:)
-    INTEGER(Int64), INTENT(IN) :: b(:)
+    INTEGER(INT64), INTENT(IN) :: a(:)
+    INTEGER(INT64), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans(SIZE(a))
   END FUNCTION isin_1d
 
@@ -204,26 +204,26 @@ END INTERFACE OPERATOR(.isin.)
 INTERFACE
 
   MODULE PURE FUNCTION in_2a(a, b) RESULT(Ans)
-    INTEGER(Int8), INTENT(IN) :: a
-    INTEGER(Int8), INTENT(IN) :: b(:)
+    INTEGER(INT8), INTENT(IN) :: a
+    INTEGER(INT8), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_2a
 
   MODULE PURE FUNCTION in_2b(a, b) RESULT(Ans)
-    INTEGER(Int16), INTENT(IN) :: a
-    INTEGER(Int16), INTENT(IN) :: b(:)
+    INTEGER(INT16), INTENT(IN) :: a
+    INTEGER(INT16), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_2b
 
   MODULE PURE FUNCTION in_2c(a, b) RESULT(Ans)
-    INTEGER(Int32), INTENT(IN) :: a
-    INTEGER(Int32), INTENT(IN) :: b(:)
+    INTEGER(INT32), INTENT(IN) :: a
+    INTEGER(INT32), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_2c
 
   MODULE PURE FUNCTION in_2d(a, b) RESULT(Ans)
-    INTEGER(Int64), INTENT(IN) :: a
-    INTEGER(Int64), INTENT(IN) :: b(:)
+    INTEGER(INT64), INTENT(IN) :: a
+    INTEGER(INT64), INTENT(IN) :: b(:)
     LOGICAL(LGT) :: ans
   END FUNCTION in_2d
 
@@ -243,16 +243,16 @@ END INTERFACE OPERATOR(.isin.)
 
 INTERFACE
   MODULE PURE SUBROUTINE RemoveDuplicates_1a(obj)
-    INTEGER(Int8), ALLOCATABLE, INTENT(INOUT) :: obj(:)
+    INTEGER(INT8), ALLOCATABLE, INTENT(INOUT) :: obj(:)
   END SUBROUTINE RemoveDuplicates_1a
   MODULE PURE SUBROUTINE RemoveDuplicates_1b(obj)
-    INTEGER(Int16), ALLOCATABLE, INTENT(INOUT) :: obj(:)
+    INTEGER(INT16), ALLOCATABLE, INTENT(INOUT) :: obj(:)
   END SUBROUTINE RemoveDuplicates_1b
   MODULE PURE SUBROUTINE RemoveDuplicates_1c(obj)
-    INTEGER(Int32), ALLOCATABLE, INTENT(INOUT) :: obj(:)
+    INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: obj(:)
   END SUBROUTINE RemoveDuplicates_1c
   MODULE PURE SUBROUTINE RemoveDuplicates_1d(obj)
-    INTEGER(Int64), ALLOCATABLE, INTENT(INOUT) :: obj(:)
+    INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: obj(:)
   END SUBROUTINE RemoveDuplicates_1d
 END INTERFACE
 
@@ -267,24 +267,24 @@ END INTERFACE RemoveDuplicates
 
 INTERFACE
   MODULE PURE FUNCTION Repeat_1a(Val, rtimes) RESULT(Ans)
-    INTEGER(Int8), INTENT(IN) :: Val(:)
+    INTEGER(INT8), INTENT(IN) :: Val(:)
     INTEGER(I4B), INTENT(IN) :: rtimes
-    INTEGER(Int8) :: Ans(SIZE(Val) * rtimes)
+    INTEGER(INT8) :: Ans(SIZE(Val) * rtimes)
   END FUNCTION Repeat_1a
   MODULE PURE FUNCTION Repeat_1b(Val, rtimes) RESULT(Ans)
-    INTEGER(Int16), INTENT(IN) :: Val(:)
+    INTEGER(INT16), INTENT(IN) :: Val(:)
     INTEGER(I4B), INTENT(IN) :: rtimes
-    INTEGER(Int16) :: Ans(SIZE(Val) * rtimes)
+    INTEGER(INT16) :: Ans(SIZE(Val) * rtimes)
   END FUNCTION Repeat_1b
   MODULE PURE FUNCTION Repeat_1c(Val, rtimes) RESULT(Ans)
-    INTEGER(Int32), INTENT(IN) :: Val(:)
+    INTEGER(INT32), INTENT(IN) :: Val(:)
     INTEGER(I4B), INTENT(IN) :: rtimes
-    INTEGER(Int32) :: Ans(SIZE(Val) * rtimes)
+    INTEGER(INT32) :: Ans(SIZE(Val) * rtimes)
   END FUNCTION Repeat_1c
   MODULE PURE FUNCTION Repeat_1d(Val, rtimes) RESULT(Ans)
-    INTEGER(Int64), INTENT(IN) :: Val(:)
+    INTEGER(INT64), INTENT(IN) :: Val(:)
     INTEGER(I4B), INTENT(IN) :: rtimes
-    INTEGER(Int64) :: Ans(SIZE(Val) * rtimes)
+    INTEGER(INT64) :: Ans(SIZE(Val) * rtimes)
   END FUNCTION Repeat_1d
 END INTERFACE
 


### PR DESCRIPTION
Before this commit, when we compile the Base lib by using `USE_OpenMP=OFF`, then compilation error occured.

Cause of the error: Recursive functions were not declared Recursive.

In this commit, this bug has been resolved. The Base library compiles successfully with `USE_OpenMP=OFF` option.

Changes to be committed:
modified:   install.py
modified:   package.py
modified:   src/modules/BaseMethod/src/BaseMethod.F90
modified:   src/modules/Polynomial/src/QuadrangleInterpolationUtility.F90
modified:   src/modules/Polynomial/src/RecursiveNodesUtility.F90
modified:   src/modules/Polynomial/src/TetrahedronInterpolationUtility.F90
modified:   src/modules/Polynomial/src/TriangleInterpolationUtility.F90
modified:   src/modules/Utility/src/BinomUtility.F90
modified:   src/modules/Utility/src/IntegerUtility.F90