### PR TITLE
Updating ReallocateUtility

### DIFF
--- a/src/modules/Utility/src/ReallocateUtility.F90
+++ b/src/modules/Utility/src/ReallocateUtility.F90
@@ -26,451 +26,331 @@ PUBLIC :: Reallocate
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_logical(Mat, row)
     LOGICAL(LGT), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: row
   END SUBROUTINE Reallocate_logical
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_logical
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R1(Mat, row)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: row
   END SUBROUTINE Reallocate_Real64_R1
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R1
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R1b(Mat, s)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real64_R1b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R1b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R1(Mat, row)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: row
   END SUBROUTINE Reallocate_Real32_R1
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R1
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R1b(Mat, s)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real32_R1b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R1b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R2(Mat, row, col)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :)
     INTEGER(I4B), INTENT(IN) :: row, col
   END SUBROUTINE Reallocate_Real64_R2
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R2
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R2b(Mat, s)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real64_R2b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R2b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R2(Mat, row, col)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :)
     INTEGER(I4B), INTENT(IN) :: row, col
   END SUBROUTINE Reallocate_Real32_R2
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R2
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R2b(Mat, s)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real32_R2b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R2b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R3(Mat, i1, i2, i3)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3
   END SUBROUTINE Reallocate_Real64_R3
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R3
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R3b(Mat, s)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real64_R3b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R3b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R3(Mat, i1, i2, i3)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3
   END SUBROUTINE Reallocate_Real32_R3
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R3
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R3b(Mat, s)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real32_R3b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R3b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R4(Mat, i1, i2, i3, i4)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4
   END SUBROUTINE Reallocate_Real64_R4
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R4
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R4b(Mat, s)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real64_R4b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R4b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R4(Mat, i1, i2, i3, i4)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4
   END SUBROUTINE Reallocate_Real32_R4
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R4
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R4b(Mat, s)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real32_R4b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R4b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R5(Mat, i1, i2, i3, i4, i5)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5
   END SUBROUTINE Reallocate_Real64_R5
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R5
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R5b(Mat, s)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real64_R5b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R5b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R5(Mat, i1, i2, i3, i4, i5)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5
   END SUBROUTINE Reallocate_Real32_R5
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R5
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R5b(Mat, s)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real32_R5b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R5b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R6(Mat, i1, i2, i3, i4, i5, i6)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6
   END SUBROUTINE Reallocate_Real64_R6
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R6
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R6b(Mat, s)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real64_R6b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R6b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R6(Mat, i1, i2, i3, i4, i5, i6)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6
   END SUBROUTINE Reallocate_Real32_R6
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R6
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R6b(Mat, s)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real32_R6b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R6b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R7(Mat, i1, i2, i3, i4, i5, &
     & i6, i7)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6, i7
   END SUBROUTINE Reallocate_Real64_R7
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R7
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R7b(Mat, s)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real64_R7b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R7b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R7(Mat, i1, i2, i3, i4, i5, i6, i7)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6, i7
   END SUBROUTINE Reallocate_Real32_R7
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R7
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R7b(Mat, s)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Real32_R7b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R7b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R1(Mat, row)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: row
   END SUBROUTINE Reallocate_Int64_R1
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R1
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
@@ -492,97 +372,73 @@ END INTERFACE Reallocate
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R1(Mat, row)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: row
   END SUBROUTINE Reallocate_Int32_R1
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R1
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R1b(Mat, s)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int32_R1b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R1b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int16_R1(Mat, row)
     INTEGER(INT16), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: row
   END SUBROUTINE Reallocate_Int16_R1
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int16_R1
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int16_R1b(Mat, s)
     INTEGER(INT16), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int16_R1b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int16_R1b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int8_R1(Mat, row)
     INTEGER(INT8), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: row
   END SUBROUTINE Reallocate_Int8_R1
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int8_R1
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int8_R1b(Mat, s)
     INTEGER(INT8), ALLOCATABLE, INTENT(INOUT) :: Mat(:)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int8_R1b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int8_R1b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R2(Mat, row, col)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :)
     INTEGER(I4B), INTENT(IN) :: row, col
@@ -622,321 +478,234 @@ INTERFACE
     INTEGER(INT8), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int8_R2b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R2, Reallocate_Int64_R2b
-  MODULE PROCEDURE Reallocate_Int32_R2, Reallocate_Int32_R2b
-  MODULE PROCEDURE Reallocate_Int16_R2, Reallocate_Int16_R2b
-  MODULE PROCEDURE Reallocate_Int8_R2, Reallocate_Int8_R2b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R3(Mat, i1, i2, i3)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3
   END SUBROUTINE Reallocate_Int64_R3
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R3
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R3b(Mat, s)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int64_R3b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R3b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R3(Mat, i1, i2, i3)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3
   END SUBROUTINE Reallocate_Int32_R3
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R3
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R3b(Mat, s)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int32_R3b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R3b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R4(Mat, i1, i2, i3, i4)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4
   END SUBROUTINE Reallocate_Int64_R4
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R4
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R4b(Mat, s)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int64_R4b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R4b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R4(Mat, i1, i2, i3, i4)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4
   END SUBROUTINE Reallocate_Int32_R4
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R4
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R4b(Mat, s)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int32_R4b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R4b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R5(Mat, i1, i2, i3, i4, i5)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5
   END SUBROUTINE Reallocate_Int64_R5
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R5
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R5b(Mat, s)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int64_R5b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R5b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R5(Mat, i1, i2, i3, i4, i5)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5
   END SUBROUTINE Reallocate_Int32_R5
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R5
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R5b(Mat, s)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int32_R5b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R5b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R6(Mat, i1, i2, i3, i4, i5, i6)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6
   END SUBROUTINE Reallocate_Int64_R6
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R6
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R6b(Mat, s)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int64_R6b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R6b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R6(Mat, i1, i2, i3, i4, i5, i6)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6
   END SUBROUTINE Reallocate_Int32_R6
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R6
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R6b(Mat, s)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int32_R6b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R6b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R7(Mat, i1, i2, i3, i4, i5, &
     & i6, i7)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6, i7
   END SUBROUTINE Reallocate_Int64_R7
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R7
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int64_R7b(Mat, s)
     INTEGER(INT64), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int64_R7b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int64_R7b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R7(Mat, i1, i2, i3, i4, i5, i6, i7)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: i1, i2, i3, i4, i5, i6, i7
   END SUBROUTINE Reallocate_Int32_R7
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R7
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R7b(Mat, s)
     INTEGER(INT32), ALLOCATABLE, INTENT(INOUT) :: Mat(:, :, :, :, :, :, :)
     INTEGER(I4B), INTENT(IN) :: s(:)
   END SUBROUTINE Reallocate_Int32_R7b
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R7b
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Int32_R1_6(Vec1, n1, Vec2, n2, Vec3, &
     & n3, Vec4, n4, Vec5, n5, Vec6, n6)
     INTEGER(I4B), ALLOCATABLE, INTENT(INOUT) :: Vec1(:), Vec2(:)
@@ -945,17 +714,13 @@ INTERFACE
     INTEGER(I4B), INTENT(IN) :: n1, n2
     INTEGER(I4B), OPTIONAL, INTENT(IN) :: n3, n4, n5, n6
   END SUBROUTINE Reallocate_Int32_R1_6
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Int32_R1_6
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_R1_6(Vec1, n1, Vec2, &
     & n2, Vec3, n3, Vec4, n4, Vec5, n5, Vec6, n6)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: Vec1(:), Vec2(:)
@@ -964,17 +729,13 @@ INTERFACE
     INTEGER(I4B), INTENT(IN) :: n1, n2
     INTEGER(I4B), OPTIONAL, INTENT(IN) :: n3, n4, n5, n6
   END SUBROUTINE Reallocate_Real64_R1_6
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_R1_6
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_R1_6(Vec1, n1, Vec2, &
     & n2, Vec3, n3, Vec4, n4, Vec5, n5, Vec6, n6)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: Vec1(:), Vec2(:)
@@ -983,74 +744,54 @@ INTERFACE
     INTEGER(I4B), INTENT(IN) :: n1, n2
     INTEGER(I4B), OPTIONAL, INTENT(IN) :: n3, n4, n5, n6
   END SUBROUTINE Reallocate_Real32_R1_6
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_R1_6
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_AIJ(A, nA, IA, nIA, JA, nJA)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: A(:)
     INTEGER(I4B), ALLOCATABLE, INTENT(INOUT) :: IA(:), JA(:)
     INTEGER(I4B), INTENT(IN) :: nA, nIA, nJA
   END SUBROUTINE Reallocate_Real64_AIJ
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_AIJ
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_AIJ(A, nA, IA, nIA, JA, nJA)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: A(:)
     INTEGER(I4B), ALLOCATABLE, INTENT(INOUT) :: IA(:), JA(:)
     INTEGER(I4B), INTENT(IN) :: nA, nIA, nJA
   END SUBROUTINE Reallocate_Real32_AIJ
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_AIJ
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real64_AI(A, nA, IA, nIA)
     REAL(REAL64), ALLOCATABLE, INTENT(INOUT) :: A(:)
     INTEGER(I4B), ALLOCATABLE, INTENT(INOUT) :: IA(:)
     INTEGER(I4B), INTENT(IN) :: nA, nIA
   END SUBROUTINE Reallocate_Real64_AI
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real64_AI
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------
 !                                               Reallocate@ReallocateMethods
 !----------------------------------------------------------------------------
 
-INTERFACE
+INTERFACE Reallocate
   MODULE PURE SUBROUTINE Reallocate_Real32_AI(A, nA, IA, nIA)
     REAL(REAL32), ALLOCATABLE, INTENT(INOUT) :: A(:)
     INTEGER(I4B), ALLOCATABLE, INTENT(INOUT) :: IA(:)
     INTEGER(I4B), INTENT(IN) :: nA, nIA
   END SUBROUTINE Reallocate_Real32_AI
-END INTERFACE
-
-INTERFACE Reallocate
-  MODULE PROCEDURE Reallocate_Real32_AI
 END INTERFACE Reallocate
 
 !----------------------------------------------------------------------------


### PR DESCRIPTION
Updates in Reference Element

Adding FaceConnectivity and Edge connectivity methods

---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request adds interfaces and module procedures for reallocating multidimensional arrays of different data types in Fortran.
> 
> ## What changed
> - Added interfaces for reallocating arrays of real numbers and integers with different dimensions and data types.
> - Defined module procedures for reallocating arrays of different data types (REAL64, REAL32, INT64, INT32, INT16, INT8).
> - Included interfaces for reallocating arrays with dimensions ranging from 1D to 7D.
> - Implemented subroutines for reallocating arrays based on input parameters.
> 
> ## How to test
> 1. Compile the Fortran file containing the ReallocateUtility module.
> 2. Use test cases to call the different interfaces and module procedures for reallocating arrays.
> 3. Verify that the arrays are reallocated correctly based on the input parameters.
> 4. Check for any errors or warnings during compilation and testing.
> 
> ## Why make this change
> - Enhances the functionality of the ReallocateUtility module by adding support for reallocating arrays of various data types and dimensions.
> - Provides a more flexible and efficient way to manage memory allocation for multidimensional arrays in Fortran programs.
> - Improves code readability and maintainability by organizing the reallocation procedures into separate interfaces and module procedures.
</details>