### PR TITLE
Updates in ReferenceElement_Method

### DIFF
--- a/src/modules/Geometry/src/ReferenceElement_Method.F90
+++ b/src/modules/Geometry/src/ReferenceElement_Method.F90
@@ -72,6 +72,7 @@ PUBLIC :: GetTotalCells
 PUBLIC :: ReferenceElementInfo
 PUBLIC :: RefElemGetGeoParam
 PUBLIC :: GetFaceElemType
+PUBLIC :: GetElementIndex
 
 INTEGER(I4B), PARAMETER, PUBLIC :: REFELEM_MAX_FACES = 6
 INTEGER(I4B), PARAMETER, PUBLIC :: REFELEM_MAX_EDGES = 12
@@ -128,6 +129,32 @@ END TYPE ReferenceElementInfo_
 
 TYPE(ReferenceElementInfo_), PARAMETER :: ReferenceElementInfo =  &
   & ReferenceElementInfo_()
+
+!----------------------------------------------------------------------------
+!                                         GetElementIndex@GeometryMethods
+!----------------------------------------------------------------------------
+
+!> author: Vikas Sharma, Ph. D.
+! date:  2024-03-19
+! summary:  Returns the index of an element based on its topology
+!
+!# Introduction
+!
+! Point 1
+! Line 2
+! Triangle 3
+! Quadrangle 4
+! Tetrahedron 5
+! Hexahedron 6
+! Prism 7
+! Pyramid 8
+
+INTERFACE
+  MODULE PURE FUNCTION GetElementIndex(elemType) RESULT(ans)
+    INTEGER(I4B), INTENT(IN) :: elemType
+    INTEGER(I4B) :: ans
+  END FUNCTION GetElementIndex
+END INTERFACE
 
 !----------------------------------------------------------------------------
 !                                         RefElemGetGeoParam@GeometryMethods

--- a/src/submodules/Geometry/src/ReferenceElement_Method@GeometryMethods.F90
+++ b/src/submodules/Geometry/src/ReferenceElement_Method@GeometryMethods.F90
@@ -49,6 +49,34 @@ IMPLICIT NONE
 CONTAINS
 
 !----------------------------------------------------------------------------
+!                                                     GetElementIndex
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE GetElementIndex
+SELECT CASE (elemType)
+CASE (Point)
+  ans = 1
+CASE (Line, Line3, Line4, Line5, Line6)
+  ans = 2
+CASE (Triangle, Triangle6, Triangle9, Triangle10, Triangle12,  &
+& Triangle15, Triangle21, Triangle15a)
+  ans = 3
+CASE (Quadrangle, Quadrangle8, Quadrangle9, Quadrangle16)
+  ans = 4
+CASE (Tetrahedron, Tetrahedron10, Tetrahedron20, Tetrahedron35,  &
+& Tetrahedron56)
+  ans = 5
+CASE (Hexahedron, Hexahedron27, Hexahedron20, Hexahedron64,  &
+& Hexahedron125)
+  ans = 6
+CASE (Prism, Prism15, Prism18)
+  ans = 7
+CASE (Pyramid, Pyramid13, Pyramid14)
+  ans = 8
+END SELECT
+END PROCEDURE GetElementIndex
+
+!----------------------------------------------------------------------------
 !                                                        RefElemGetGeoParam
 !----------------------------------------------------------------------------
 
@@ -66,6 +94,11 @@ CASE (Line)
   IF (PRESENT(tEdges)) tEdges = 0_I4B
   IF (PRESENT(tFaces)) tFaces = 0_I4B
 
+CASE (Line3)
+  IF (PRESENT(tNodes)) tNodes = 3_I4B
+  IF (PRESENT(tEdges)) tEdges = 0_I4B
+  IF (PRESENT(tFaces)) tFaces = 0_I4B
+
 CASE (Triangle)
   IF (PRESENT(tNodes)) tNodes = 3_I4B
   IF (PRESENT(tEdges)) tEdges = 3_I4B
@@ -73,8 +106,29 @@ CASE (Triangle)
   IF (PRESENT(edgeCon)) CALL GetEdgeConnectivity_Triangle(con=edgeCon,  &
     & opt=edgeOpt)
 
+CASE (Triangle6)
+  IF (PRESENT(tNodes)) tNodes = 6_I4B
+  IF (PRESENT(tEdges)) tEdges = 3_I4B
+  IF (PRESENT(tFaces)) tFaces = 0_I4B
+  IF (PRESENT(edgeCon)) CALL GetEdgeConnectivity_Triangle(con=edgeCon,  &
+    & opt=edgeOpt)
+
 CASE (Quadrangle)
   IF (PRESENT(tNodes)) tNodes = 4_I4B
+  IF (PRESENT(tEdges)) tEdges = 4_I4B
+  IF (PRESENT(tFaces)) tFaces = 0_I4B
+  IF (PRESENT(edgeCon)) CALL GetEdgeConnectivity_Quadrangle(con=edgeCon,  &
+    & opt=edgeOpt)
+
+CASE (Quadrangle8)
+  IF (PRESENT(tNodes)) tNodes = 8_I4B
+  IF (PRESENT(tEdges)) tEdges = 4_I4B
+  IF (PRESENT(tFaces)) tFaces = 0_I4B
+  IF (PRESENT(edgeCon)) CALL GetEdgeConnectivity_Quadrangle(con=edgeCon,  &
+    & opt=edgeOpt)
+
+CASE (Quadrangle9)
+  IF (PRESENT(tNodes)) tNodes = 9_I4B
   IF (PRESENT(tEdges)) tEdges = 4_I4B
   IF (PRESENT(tFaces)) tFaces = 0_I4B
   IF (PRESENT(edgeCon)) CALL GetEdgeConnectivity_Quadrangle(con=edgeCon,  &


### PR DESCRIPTION
### TL;DR

This pull request includes the addition of the 'GetElementIndex' method in the `Geometry` module. This new method returns the index of an element based on its topology.

### What changed?

The changes can be noted in 'src/modules/Geometry/src/ReferenceElement_Method.F90' and 'src/submodules/Geometry/src/ReferenceElement_Method@GeometryMethods.F90'. A new function, 'GetElementIndex', has been added which returns the index of geometric elements like Point, Line, Triangle, Quadrangle, Tetrahedron, Hexahedron, Prism, and Pyramid based on their type.

### How to test?

To validate these updates, build the project and validate that the new method correctly returns the expected indices when called with different geometric shapes.

### Why make this change?

This change was needed as there was no method present earlier to retrieve the index of a geometric element based on its type. Hence, this new method 'GetElementIndex' would improve the functionality of the Geometry module.

---

