### PR TITLE
Refine CSR matrix unary and sym methods

### DIFF
--- a/src/modules/CSRMatrix/src/CSRMatrix_SetMethods.F90
+++ b/src/modules/CSRMatrix/src/CSRMatrix_SetMethods.F90
@@ -16,7 +16,7 @@
 
 MODULE CSRMatrix_SetMethods
 USE GlobalData, ONLY: I4B, DFP, LGT
-USE BaSetype, ONLY: CSRMatrix_
+USE BaseType, ONLY: CSRMatrix_
 IMPLICIT NONE
 
 PRIVATE

--- a/src/submodules/CSRMatrix/src/CSRMatrix_UnaryMethods@Methods.F90
+++ b/src/submodules/CSRMatrix/src/CSRMatrix_UnaryMethods@Methods.F90
@@ -16,7 +16,24 @@
 !
 
 SUBMODULE(CSRMatrix_UnaryMethods) Methods
-USE BaseMethod
+USE GlobalData, ONLY: stderr
+USE BaseType, ONLY: math => TypeMathOpt
+USE BaseType, ONLY: DOF_
+USE BaseType, ONLY: CSRSparsity_
+USE F95_BLAS, ONLY: BlasSCAL => Scal
+USE ReallocateUtility, ONLY: Reallocate
+USE CSRMatrix_Method, ONLY: CSRMatrixSize => Size
+USE CSRMatrix_Method, ONLY: SetTotalDimension
+USE CSRMatrix_Method, ONLY: CSRMatrixInitiate => Initiate
+USE CSRMatrix_Method, ONLY: CSRMatrixSetSparsity => SetSparsity
+USE RealMatrix_Method, ONLY: RealMatrixSetTotalDimension => &
+                             SetTotalDimension
+USE InputUtility, ONLY: Input
+USE ErrorHandling, ONLY: ErrorMSG
+USE CSRSparsity_Method, ONLY: CSRSparsityGetDiagonal => GetDiagonal
+USE CSRSparsity_Method, ONLY: CSRSparsityGetNNZ => GetNNZ
+USE DOF_Method, ONLY: DOFDeallocate => DEALLOCATE
+
 IMPLICIT NONE
 CONTAINS
 
@@ -25,7 +42,7 @@ CONTAINS
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_Scal
-CALL SCAL(X=obj%A, A=a)
+CALL BlasSCAL(X=obj%A, A=a)
 END PROCEDURE obj_Scal
 
 !----------------------------------------------------------------------------
@@ -49,18 +66,17 @@ END PROCEDURE obj_Convert1
 
 MODULE PROCEDURE obj_Convert2
 INTEGER(I4B) :: i, j, nrow, ncol
-!!
-nrow = SIZE(obj=From, dims=1)
-ncol = SIZE(obj=From, dims=2)
-!!
+
+nrow = CSRMatrixSize(obj=from, dims=1)
+ncol = CSRMatrixSize(obj=from, dims=2)
+
 CALL Reallocate(To, nrow, ncol)
-!!
+
 DO i = 1, nrow
   DO j = From%csr%IA(i), From%csr%IA(i + 1) - 1
     To(i, From%csr%JA(j)) = From%A(j)
   END DO
 END DO
-!!
 END PROCEDURE obj_Convert2
 
 !----------------------------------------------------------------------------
@@ -68,10 +84,8 @@ END PROCEDURE obj_Convert2
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_Convert3
-CALL Convert(From=From, To=To%val)
-! CALL Convert(A=From%A, IA=From%csr%IA, JA=From%csr%JA, &
-!   & mat=To%val)
-CALL setTotalDimension(To, 2_I4B)
+CALL Convert(from=from, to=to%val)
+CALL RealMatrixSetTotalDimension(obj=to, tDimension=math%two_i)
 END PROCEDURE obj_Convert3
 
 !----------------------------------------------------------------------------
@@ -79,9 +93,12 @@ END PROCEDURE obj_Convert3
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_ColumnSORT
+LOGICAL(LGT) :: isValues0
+
+isValues0 = Input(option=isValues, default=math%yes)
 CALL CSORT(obj%csr%nrow, obj%A, obj%csr%JA, obj%csr%IA, &
-  & INPUT(Option=isValues, Default=.TRUE.))
-obj%csr%isSorted = .TRUE.
+           isValues0)
+obj%csr%isSorted = math%yes
 END PROCEDURE obj_ColumnSORT
 
 !----------------------------------------------------------------------------
@@ -90,11 +107,12 @@ END PROCEDURE obj_ColumnSORT
 
 MODULE PROCEDURE obj_RemoveDuplicates
 INTEGER(I4B), ALLOCATABLE :: iwk(:), UT(:)
+
 CALL Reallocate(UT, obj%csr%nrow, iwk, obj%csr%nrow + 1)
 CALL CLNCSR(1, 1, obj%csr%nrow, obj%A, obj%csr%JA, obj%csr%IA, UT, iwk)
 !> Some entries are removed so fix sparsity
-obj%csr%isSparsityLock = .FALSE.
-CALL setSparsity(obj)
+obj%csr%isSparsityLock = math%no
+CALL CSRMatrixSetSparsity(obj)
 DEALLOCATE (iwk, UT)
 END PROCEDURE obj_RemoveDuplicates
 
@@ -104,19 +122,20 @@ END PROCEDURE obj_RemoveDuplicates
 
 MODULE PROCEDURE obj_Clean
 INTEGER(I4B), ALLOCATABLE :: iwk(:), UT(:)
-INTEGER(I4B) :: value2
+INTEGER(I4B) :: value2, extraOption0
+LOGICAL(LGT) :: isValues0
 
-IF (INPUT(option=isValues, default=.TRUE.)) THEN
-  value2 = 1
-ELSE
-  value2 = 0
-END IF
+isValues0 = INPUT(option=isValues, default=math%yes)
+extraOption0 = INPUT(option=extraOption, default=math%one_i)
+value2 = 0
+IF (isValues0) value2 = 1
+
 CALL Reallocate(UT, obj%csr%nrow, iwk, obj%csr%nrow + 1)
-CALL CLNCSR(INPUT(option=ExtraOption, default=1), value2, obj%csr%nrow, &
-  & obj%A, obj%csr%JA, obj%csr%IA, UT, iwk)
+CALL CLNCSR(extraOption0, value2, obj%csr%nrow, &
+            obj%A, obj%csr%JA, obj%csr%IA, UT, iwk)
 !> Some entries are removed so fix sparsity
-obj%csr%isSparsityLock = .FALSE.
-CALL setSparsity(obj)
+obj%csr%isSparsityLock = math%no
+CALL CSRMatrixSetSparsity(obj)
 DEALLOCATE (iwk, UT)
 END PROCEDURE obj_Clean
 
@@ -125,7 +144,7 @@ END PROCEDURE obj_Clean
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_Copy
-To = From
+to = from
 END PROCEDURE obj_Copy
 
 !----------------------------------------------------------------------------
@@ -149,16 +168,20 @@ END PROCEDURE obj_Get1
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_DropEntry
-INTEGER(I4B) :: ierr, nnz
+INTEGER(I4B) :: ierr, nnz, option0
 INTEGER(I4B), ALLOCATABLE :: IA(:), JA(:)
 REAL(DFP), ALLOCATABLE :: A(:)
+
 ALLOCATE (IA(objIn%csr%nrow + 1), JA(objIn%csr%nnz), &
-  & A(objIn%csr%nnz))
-CALL FILTER(objIn%csr%nrow, INPUT(option=option, default=1), &
-  & droptol, objIn%A, objIn%csr%JA, objIn%csr%IA, A, JA, IA,&
-  & objIn%csr%nnz, ierr)
+          A(objIn%csr%nnz))
+
+option0 = INPUT(option=option, default=math%one_i)
+
+CALL FILTER(objIn%csr%nrow, option0, &
+            droptol, objIn%A, objIn%csr%JA, objIn%csr%IA, A, JA, IA, &
+            objIn%csr%nnz, ierr)
 nnz = IA(objIn%csr%nrow + 1) - 1
-CALL Initiate(obj=objOut, A=A(1:nnz), IA=IA, JA=JA(1:nnz))
+CALL CSRMatrixInitiate(obj=objOut, A=A(1:nnz), IA=IA, JA=JA(1:nnz))
 DEALLOCATE (IA, JA, A)
 END PROCEDURE obj_DropEntry
 
@@ -170,22 +193,25 @@ MODULE PROCEDURE obj_Transpose
 INTEGER(I4B), ALLOCATABLE :: iwk(:)
 INTEGER(I4B) :: ierr
 TYPE(DOF_) :: dofobj
+
 CALL Reallocate(iwk, obj%csr%nnz)
 CALL TRANSP(obj%csr%nrow,obj%csr%ncol,obj%A,obj%csr%JA,obj%csr%IA,iwk,ierr)
+
 IF (ierr .NE. 0) THEN
   CALL ErrorMSG( &
-    & msg="Error occured during transposing!", &
-    & file="CSRMatrix_Method@UnaryMethods.F90", &
-    & routine="obj_Transpose()", &
-    & line=__LINE__, &
-    & unitno=stderr)
+    msg="Error occured during transposing!", &
+    file="CSRMatrix_Method@UnaryMethods.F90", &
+    routine="obj_Transpose()", &
+    line=__LINE__, &
+    unitno=stderr)
   STOP
 END IF
+
 CALL ColumnSORT(obj)
 dofobj = obj%csr%idof
 obj%csr%jdof = obj%csr%idof
 obj%csr%idof = dofobj
-CALL DEALLOCATE (dofobj)
+CALL DOFDeallocate(dofobj)
 DEALLOCATE (iwk)
 END PROCEDURE obj_Transpose
 
@@ -193,34 +219,35 @@ END PROCEDURE obj_Transpose
 !                                                                 getDiagonal
 !----------------------------------------------------------------------------
 
-MODULE PROCEDURE obj_getDiagonal1
-CALL getDiagonal(obj=obj%csr, A=obj%A, diag=diag, idiag=idiag, &
-  & offset=offset)
-END PROCEDURE obj_getDiagonal1
+MODULE PROCEDURE obj_GetDiagonal1
+CALL CSRSparsityGetDiagonal(obj=obj%csr, A=obj%A, diag=diag, idiag=idiag, &
+                            offset=offset)
+END PROCEDURE obj_GetDiagonal1
 
 !----------------------------------------------------------------------------
 !                                                                 getDiagonal
 !----------------------------------------------------------------------------
 
-MODULE PROCEDURE obj_getDiagonal2
-CALL getDiagonal(obj=obj%csr, A=obj%A, diag=diag, offset=offset)
-END PROCEDURE obj_getDiagonal2
+MODULE PROCEDURE obj_GetDiagonal2
+CALL CSRSparsityGetDiagonal(obj=obj%csr, A=obj%A, diag=diag, offset=offset)
+END PROCEDURE obj_GetDiagonal2
 
 !----------------------------------------------------------------------------
 !                                                          getLowerTriangle
 !----------------------------------------------------------------------------
 
-MODULE PROCEDURE obj_getLowerTriangle
+MODULE PROCEDURE obj_GetLowerTriangle
 REAL(DFP), ALLOCATABLE :: A(:)
 INTEGER(I4B), ALLOCATABLE :: IA(:), JA(:)
 INTEGER(I4B) :: nnz, nrow
-nrow = obj%csr%nrow; nnz = obj%csr%nnz
+nrow = obj%csr%nrow
+nnz = obj%csr%nnz
 ALLOCATE (A(nnz), JA(nnz), IA(nrow + 1))
 CALL GETL(obj%csr%nrow, obj%A, obj%csr%JA, obj%csr%IA, A, JA, IA)
 nnz = IA(nrow + 1) - 1
-CALL Initiate(obj=L, A=A(1:nnz), IA=IA, JA=JA(1:nnz))
+CALL CSRMatrixInitiate(obj=L, A=A(1:nnz), IA=IA, JA=JA(1:nnz))
 DEALLOCATE (A, IA, JA)
-END PROCEDURE obj_getLowerTriangle
+END PROCEDURE obj_GetLowerTriangle
 
 !----------------------------------------------------------------------------
 !                                                          getUpperTriangle
@@ -230,11 +257,13 @@ MODULE PROCEDURE obj_getUpperTriangle
 REAL(DFP), ALLOCATABLE :: A(:)
 INTEGER(I4B), ALLOCATABLE :: IA(:), JA(:)
 INTEGER(I4B) :: nnz, nrow
-nrow = obj%csr%nrow; nnz = obj%csr%nnz
+
+nrow = obj%csr%nrow
+nnz = obj%csr%nnz
 ALLOCATE (A(nnz), JA(nnz), IA(nrow + 1))
 CALL GETU(obj%csr%nrow, obj%A, obj%csr%JA, obj%csr%IA, A, JA, IA)
 nnz = IA(nrow + 1) - 1
-CALL Initiate(obj=U, A=A(1:nnz), IA=IA, JA=JA(1:nnz))
+CALL CSRMatrixInitiate(obj=U, A=A(1:nnz), IA=IA, JA=JA(1:nnz))
 DEALLOCATE (A, IA, JA)
 END PROCEDURE obj_getUpperTriangle
 
@@ -244,13 +273,18 @@ END PROCEDURE obj_getUpperTriangle
 
 MODULE PROCEDURE obj_PermuteRow
 INTEGER(I4B) :: nrow, job
-nrow = SIZE(obj, 1); job = 1
-IF (PRESENT(isValues)) THEN
+LOGICAL(LGT) :: isok
+
+nrow = CSRMatrixSIZE(obj, 1)
+job = 1
+isok = PRESENT(isValues)
+
+IF (isok) THEN
   IF (.NOT. isValues) job = 0
 END IF
-CALL initiate(ans, obj, .TRUE.)
+CALL CSRMatrixInitiate(ans, obj, math%yes)
 CALL RPERM(nrow, obj%A, obj%csr%JA, obj%csr%IA, ans%A, ans%csr%JA, &
-  & ans%csr%IA, PERM, job)
+           ans%csr%IA, PERM, job)
 END PROCEDURE obj_PermuteRow
 
 !----------------------------------------------------------------------------
@@ -259,13 +293,17 @@ END PROCEDURE obj_PermuteRow
 
 MODULE PROCEDURE obj_PermuteColumn
 INTEGER(I4B) :: nrow, job
-nrow = SIZE(obj, 1); job = 1
-IF (PRESENT(isValues)) THEN
+LOGICAL(LGT) :: isok
+
+nrow = CSRMatrixSIZE(obj, 1)
+job = 1
+isok = PRESENT(isValues)
+IF (isok) THEN
   IF (.NOT. isValues) job = 0
 END IF
-CALL initiate(ans, obj, .TRUE.)
+CALL CSRMatrixInitiate(ans, obj, math%yes)
 CALL CPERM(nrow, obj%A, obj%csr%JA, obj%csr%IA, ans%A, ans%csr%JA, &
-  & ans%csr%IA, PERM, job)
+           ans%csr%IA, PERM, job)
 END PROCEDURE obj_PermuteColumn
 
 !----------------------------------------------------------------------------
@@ -274,50 +312,51 @@ END PROCEDURE obj_PermuteColumn
 
 MODULE PROCEDURE obj_Permute
 INTEGER(I4B) :: nrow, job
-LOGICAL(LGT) :: isSymPERM
-!
-nrow = SIZE(obj, 1)
-CALL initiate(ans, obj, .TRUE.)
-!
-IF (PRESENT(symPERM)) THEN
-  isSymPERM = symPERM
-ELSE
-  isSymPERM = .FALSE.
-END IF
-!
-IF (PRESENT(rowPERM) .AND. PRESENT(colPERM)) THEN
+LOGICAL(LGT) :: isSymPERM, isok
+
+nrow = CSRMatrixSIZE(obj, 1)
+CALL CSRMatrixInitiate(ans, obj, math%yes)
+
+isok = PRESENT(symPERM)
+isSymPERM = math%no
+IF (isok) isSymPERM = symPERM
+
+isok = PRESENT(rowPERM) .AND. PRESENT(colPERM)
+IF (isok) THEN
   job = 3
   IF (PRESENT(isValues)) THEN
     IF (.NOT. isValues) job = 4
   END IF
   CALL DPERM(nrow, obj%A, obj%csr%JA, obj%csr%IA, ans%A, &
-    & ans%csr%JA, ans%csr%IA, rowPERM, colPERM, job)
+             ans%csr%JA, ans%csr%IA, rowPERM, colPERM, job)
   RETURN
 END IF
-!
-IF (PRESENT(rowPERM)) THEN
+
+isok = PRESENT(rowPERM)
+IF (isok) THEN
   IF (isSymPERM) THEN
     job = 1
     IF (PRESENT(isValues)) THEN
       IF (.NOT. isValues) job = 2
     END IF
     CALL DPERM(nrow, obj%A, obj%csr%JA, obj%csr%IA, ans%A, &
-      & ans%csr%JA, ans%csr%IA, rowPERM, rowPERM, job)
+               ans%csr%JA, ans%csr%IA, rowPERM, rowPERM, job)
     RETURN
   ELSE
     ans = PermuteRow(obj=obj, PERM=rowPERM, isValues=isValues)
     RETURN
   END IF
 END IF
-!
-IF (PRESENT(colPERM)) THEN
+
+isok = PRESENT(colPERM)
+IF (isok) THEN
   IF (isSymPERM) THEN
     job = 1
     IF (PRESENT(isValues)) THEN
       IF (.NOT. isValues) job = 2
     END IF
     CALL DPERM(nrow, obj%A, obj%csr%JA, obj%csr%IA, ans%A, &
-      & ans%csr%JA, ans%csr%IA, colPERM, colPERM, job)
+               ans%csr%JA, ans%csr%IA, colPERM, colPERM, job)
     RETURN
   ELSE
     ans = PermuteColumn(obj=obj, PERM=colPERM, isValues=isValues)
@@ -335,31 +374,31 @@ SUBROUTINE obj_GetSymU1(obj, symobj, A, symA)
   TYPE(CSRSparsity_), INTENT(INOUT) :: symobj
   REAL(DFP), INTENT(IN) :: A(:)
   REAL(DFP), ALLOCATABLE, INTENT(INOUT) :: symA(:)
-  !
+  ! Define internal variables
   INTEGER(I4B) :: nnz_parts(3), ii, jj, rindx, indx, nrow, nnzU, ncol, &
-    & nnzD, al, ar, ad
+                  nnzD, al, ar, ad
   INTEGER(I4B), ALLOCATABLE :: IA_csr(:), IA_csc(:), JA_csr(:), &
-    & JA_csc(:), idiag(:)
+                               JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:)
-  !
-  nnz_parts = GetNNZ(obj, [""])
+  CHARACTER(1), PARAMETER :: from(1) = [" "]
+
+  nnz_parts = CSRSparsityGetNNZ(obj, from)
   nrow = obj%nrow
   ncol = obj%ncol
   nnzU = nnz_parts(1)
   nnzD = nnz_parts(3)
-  !
+
   CALL Reallocate(JA_csr, nnzU, IA_csr, nrow + 1)
   CALL Reallocate(idiag, nrow)
   CALL Reallocate(A_csc, nnzU)
   CALL Reallocate(A_csr, nnzU)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, nrow
-    !
     IA_csr(ii) = indx + 1
     IA_csr(ii + 1) = IA_csr(ii)
-    !
+
     DO rindx = obj%IA(ii), obj%IA(ii + 1) - 1
       jj = obj%JA(rindx)
       IF (ii .LT. jj) THEN
@@ -371,39 +410,29 @@ SUBROUTINE obj_GetSymU1(obj, symobj, A, symA)
         idiag(ii) = rindx
       END IF
     END DO
-    !
   END DO
-  !
+
   CALL Reallocate(IA_csc, ncol + 1, JA_csc, nnzU)
   CALL Reallocate(A_csc, nnzU)
-  !
-  CALL csrcsc( &
-    & nrow, &
-    & 1, &
-    & 1, &
-    & A_csr, &
-    & JA_csr, &
-    & IA_csr, &
-    & A_csc, &
-    & JA_csc, &
-    & IA_csc)
-  !
+
+  CALL csrcsc(nrow, 1, 1, A_csr, JA_csr, IA_csr, A_csc, JA_csc, IA_csc)
+
   symobj%nnz = nnzU * 2 + nnzD
   symobj%ncol = ncol
   symobj%nrow = nrow
   symobj%isSorted = obj%isSorted
   symobj%isInitiated = obj%isInitiated
   symobj%isSparsityLock = obj%isSparsityLock
-  symobj%isDiagStored = .TRUE.
+  symobj%isDiagStored = math%yes
   symobj%idof = obj%idof
   symobj%jdof = obj%jdof
-  !
+
   CALL Reallocate(symobj%IA, nrow + 1, symobj%idiag, nrow)
   CALL Reallocate(symobj%JA, symobj%nnz)
   CALL Reallocate(symA, symobj%nnz)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, symobj%nrow
     ar = IA_csr(ii + 1) - IA_csr(ii)
     al = IA_csc(ii + 1) - IA_csr(ii)
@@ -412,35 +441,33 @@ SUBROUTINE obj_GetSymU1(obj, symobj, A, symA)
     ELSE
       ad = 0
     END IF
-    !
+
     symobj%IA(ii) = indx + 1
     symobj%IA(ii + 1) = symobj%IA(ii) + ar + al + ad
-    !
+
     DO rindx = IA_csc(ii), IA_csc(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csc(rindx)
       symA(indx) = A_csc(rindx)
     END DO
-    !
+
     IF (idiag(ii) .NE. 0) THEN
       indx = indx + 1
-      symobj%JA(indx) = ii !!obj%JA(idiag(ii))
+      symobj%JA(indx) = ii
+      !!obj%JA(idiag(ii))
       symobj%idiag(ii) = indx
       symA(indx) = A(idiag(ii))
     END IF
-    !
+
     DO rindx = IA_csr(ii), IA_csr(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csr(rindx)
       symA(indx) = A_csr(rindx)
     END DO
-    !
   END DO
-  !
+
   ! Clean up
-  !
   DEALLOCATE (IA_csr, IA_csc, JA_csr, JA_csc, idiag, A_csr, A_csc)
-  !
 END SUBROUTINE obj_GetSymU1
 
 !----------------------------------------------------------------------------
@@ -450,32 +477,33 @@ END SUBROUTINE obj_GetSymU1
 SUBROUTINE obj_GetSymU2(obj, A)
   TYPE(CSRSparsity_), INTENT(INOUT) :: obj
   REAL(DFP), ALLOCATABLE, INTENT(INOUT) :: A(:)
-  !
+  ! define internal variables
   INTEGER(I4B) :: nnz_parts(3), ii, jj, rindx, indx, nrow, nnzU, ncol, &
     & nnzD, al, ar, ad
   INTEGER(I4B), ALLOCATABLE :: IA_csr(:), IA_csc(:), JA_csr(:), &
     & JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:), A_diag(:)
-  !
-  nnz_parts = GetNNZ(obj, [""])
+  CHARACTER(1), PARAMETER :: from(1) = [" "]
+
+  nnz_parts = CSRSparsityGetNNZ(obj, from)
   nrow = obj%nrow
   ncol = obj%ncol
   nnzU = nnz_parts(1)
   nnzD = nnz_parts(3)
-  !
+
   CALL Reallocate(JA_csr, nnzU, IA_csr, nrow + 1)
   CALL Reallocate(idiag, nrow)
   CALL Reallocate(A_csc, nnzU)
   CALL Reallocate(A_csr, nnzU)
   CALL Reallocate(A_diag, nrow)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, nrow
-    !
+
     IA_csr(ii) = indx + 1
     IA_csr(ii + 1) = IA_csr(ii)
-    !
+
     DO rindx = obj%IA(ii), obj%IA(ii + 1) - 1
       jj = obj%JA(rindx)
       IF (ii .LT. jj) THEN
@@ -488,32 +516,22 @@ SUBROUTINE obj_GetSymU2(obj, A)
         A_diag(ii) = A(rindx)
       END IF
     END DO
-    !
   END DO
-  !
+
   CALL Reallocate(IA_csc, ncol + 1, JA_csc, nnzU)
   CALL Reallocate(A_csc, nnzU)
-  !
-  CALL csrcsc( &
-    & nrow, &
-    & 1, &
-    & 1, &
-    & A_csr, &
-    & JA_csr, &
-    & IA_csr, &
-    & A_csc, &
-    & JA_csc, &
-    & IA_csc)
-  !
+
+  CALL csrcsc(nrow, 1, 1, A_csr, JA_csr, IA_csr, A_csc, JA_csc, IA_csc)
+
   obj%nnz = nnz_parts(1) * 2 + nnz_parts(3)
-  obj%isDiagStored = .TRUE.
-  !
+  obj%isDiagStored = math%yes
+
   CALL Reallocate(obj%IA, nrow + 1, obj%idiag, nrow)
   CALL Reallocate(obj%JA, obj%nnz)
   CALL Reallocate(A, obj%nnz)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, obj%nrow
     ar = IA_csr(ii + 1) - IA_csr(ii)
     al = IA_csc(ii + 1) - IA_csr(ii)
@@ -522,36 +540,34 @@ SUBROUTINE obj_GetSymU2(obj, A)
     ELSE
       ad = 0
     END IF
-    !
+
     obj%IA(ii) = indx + 1
     obj%IA(ii + 1) = obj%IA(ii) + ar + al + ad
-    !
+
     DO rindx = IA_csc(ii), IA_csc(ii + 1) - 1
       indx = indx + 1
       obj%JA(indx) = JA_csc(rindx)
       A(indx) = A_csc(rindx)
     END DO
-    !
+
     IF (idiag(ii) .NE. 0) THEN
       indx = indx + 1
-      obj%JA(indx) = ii !!obj%JA(idiag(ii))
+      obj%JA(indx) = ii
+      !!obj%JA(idiag(ii))
       obj%idiag(ii) = indx
       A(indx) = A_diag(ii)
     END IF
-    !
+
     DO rindx = IA_csr(ii), IA_csr(ii + 1) - 1
       indx = indx + 1
       obj%JA(indx) = JA_csr(rindx)
       A(indx) = A_csr(rindx)
     END DO
-    !
   END DO
-  !
+
   ! Clean up
-  !
   DEALLOCATE (IA_csr, IA_csc, JA_csr, JA_csc, idiag, A_csr, &
-    & A_csc, A_diag)
-  !
+              A_csc, A_diag)
 END SUBROUTINE obj_GetSymU2
 
 !----------------------------------------------------------------------------
@@ -563,26 +579,27 @@ SUBROUTINE obj_GetSymL1(obj, symobj, A, symA)
   TYPE(CSRSparsity_), INTENT(INOUT) :: symobj
   REAL(DFP), INTENT(IN) :: A(:)
   REAL(DFP), ALLOCATABLE, INTENT(INOUT) :: symA(:)
-  !
+  ! Internal variables
   INTEGER(I4B) :: nnz_parts(3), ii, jj, rindx, indx, nrow, nnzL, ncol, &
-    & nnzD, al, ar, ad
+                  nnzD, al, ar, ad
   INTEGER(I4B), ALLOCATABLE :: IA_csr(:), IA_csc(:), JA_csr(:), &
-    & JA_csc(:), idiag(:)
+                               JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:), A_diag(:)
-  !
-  nnz_parts = GetNNZ(obj, [""])
+  CHARACTER(1), PARAMETER :: from(1) = [" "]
+
+  nnz_parts = CSRSparsityGetNNZ(obj, from)
   nrow = obj%nrow
   ncol = obj%ncol
   nnzL = nnz_parts(2)
   nnzD = nnz_parts(3)
-  !
+
   CALL Reallocate(JA_csr, nnzL, IA_csr, nrow + 1)
   CALL Reallocate(idiag, nrow)
   CALL Reallocate(A_csr, nnzL)
   CALL Reallocate(A_diag, nrow)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, nrow
     IA_csr(ii) = indx + 1
     IA_csr(ii + 1) = IA_csr(ii)
@@ -599,10 +616,10 @@ SUBROUTINE obj_GetSymL1(obj, symobj, A, symA)
       END IF
     END DO
   END DO
-  !
+
   CALL Reallocate(IA_csc, ncol + 1, JA_csc, nnzL)
   CALL Reallocate(A_csc, nnzL)
-  !
+
   CALL csrcsc( &
     & nrow, &
     & 1, &
@@ -613,23 +630,23 @@ SUBROUTINE obj_GetSymL1(obj, symobj, A, symA)
     & A_csc, &
     & JA_csc, &
     & IA_csc)
-  !
+
   symobj%nnz = nnzL * 2 + nnzD
   symobj%ncol = ncol
   symobj%nrow = nrow
   symobj%isSorted = obj%isSorted
   symobj%isInitiated = obj%isInitiated
   symobj%isSparsityLock = obj%isSparsityLock
-  symobj%isDiagStored = .TRUE.
+  symobj%isDiagStored = math%yes
   symobj%idof = obj%idof
   symobj%jdof = obj%jdof
-  !
+
   CALL Reallocate(symobj%IA, nrow + 1, symobj%idiag, nrow)
   CALL Reallocate(symobj%JA, symobj%nnz)
   CALL Reallocate(symA, symobj%nnz)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, symobj%nrow
     al = IA_csr(ii + 1) - IA_csr(ii)
     ar = IA_csc(ii + 1) - IA_csc(ii)
@@ -638,35 +655,34 @@ SUBROUTINE obj_GetSymL1(obj, symobj, A, symA)
     ELSE
       ad = 0
     END IF
-    !
+
     symobj%IA(ii) = indx + 1
     symobj%IA(ii + 1) = symobj%IA(ii) + ar + al + ad
-    !
+
     DO rindx = IA_csr(ii), IA_csr(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csr(rindx)
       symA(indx) = A_csr(rindx)
     END DO
-    !
+
     IF (idiag(ii) .NE. 0) THEN
       indx = indx + 1
-      symobj%JA(indx) = ii !!obj%JA(idiag(ii))
+      symobj%JA(indx) = ii
+      !!obj%JA(idiag(ii))
       symobj%idiag(ii) = indx
       symA(indx) = A_diag(ii)
     END IF
-    !
+
     DO rindx = IA_csc(ii), IA_csc(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csc(rindx)
       symA(indx) = A_csc(rindx)
     END DO
-    !
+
   END DO
-  !
+
   ! Clean up
-  !
   DEALLOCATE (IA_csr, IA_csc, JA_csr, JA_csc, idiag, A_csr, A_csc, A_diag)
-  !
 END SUBROUTINE obj_GetSymL1
 
 !----------------------------------------------------------------------------
@@ -676,26 +692,27 @@ END SUBROUTINE obj_GetSymL1
 SUBROUTINE obj_GetSymL2(obj, A)
   TYPE(CSRSparsity_), INTENT(INOUT) :: obj
   REAL(DFP), ALLOCATABLE, INTENT(INOUT) :: A(:)
-  !
+  ! Define internal variables
   INTEGER(I4B) :: nnz_parts(3), ii, jj, rindx, indx, nrow, nnzL, ncol, &
-    & nnzD, al, ar, ad
+                  nnzD, al, ar, ad
   INTEGER(I4B), ALLOCATABLE :: IA_csr(:), IA_csc(:), JA_csr(:), &
-    & JA_csc(:), idiag(:)
+                               JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:), A_diag(:)
-  !
-  nnz_parts = GetNNZ(obj, [""])
+  CHARACTER(1), PARAMETER :: from(1) = [" "]
+
+  nnz_parts = CSRSparsityGetNNZ(obj, from)
   nrow = obj%nrow
   ncol = obj%ncol
   nnzL = nnz_parts(2)
   nnzD = nnz_parts(3)
-  !
+
   CALL Reallocate(JA_csr, nnzL, IA_csr, nrow + 1)
   CALL Reallocate(idiag, nrow)
   CALL Reallocate(A_csr, nnzL)
   CALL Reallocate(A_Diag, nrow)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, nrow
     IA_csr(ii) = indx + 1
     IA_csr(ii + 1) = IA_csr(ii)
@@ -712,75 +729,63 @@ SUBROUTINE obj_GetSymL2(obj, A)
       END IF
     END DO
   END DO
-  !
+
   CALL Reallocate(IA_csc, ncol + 1, JA_csc, nnzL)
   CALL Reallocate(A_csc, nnzL)
-  !
-  CALL csrcsc( &
-    & nrow, &
-    & 1, &
-    & 1, &
-    & A_csr, &
-    & JA_csr, &
-    & IA_csr, &
-    & A_csc, &
-    & JA_csc, &
-    & IA_csc)
-  !
+
+  CALL csrcsc(nrow, 1, 1, A_csr, JA_csr, IA_csr, A_csc, JA_csc, IA_csc)
+
   obj%nnz = nnzL * 2 + nnzD
   obj%ncol = ncol
   obj%nrow = nrow
   obj%isSorted = obj%isSorted
   obj%isInitiated = obj%isInitiated
   obj%isSparsityLock = obj%isSparsityLock
-  obj%isDiagStored = .TRUE.
+  obj%isDiagStored = math%yes
   obj%idof = obj%idof
   obj%jdof = obj%jdof
-  !
+
   CALL Reallocate(obj%IA, nrow + 1, obj%idiag, nrow)
   CALL Reallocate(obj%JA, obj%nnz)
   CALL Reallocate(A, obj%nnz)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, obj%nrow
     al = IA_csr(ii + 1) - IA_csr(ii)
     ar = IA_csc(ii + 1) - IA_csc(ii)
-    !
+
     IF (idiag(ii) .NE. 0) THEN
       ad = 1
     ELSE
       ad = 0
     END IF
-    !
+
     obj%IA(ii) = indx + 1
     obj%IA(ii + 1) = obj%IA(ii) + ar + al + ad
-    !
+
     DO rindx = IA_csr(ii), IA_csr(ii + 1) - 1
       indx = indx + 1
       obj%JA(indx) = JA_csr(rindx)
       A(indx) = A_csr(rindx)
     END DO
-    !
+
     IF (idiag(ii) .NE. 0) THEN
       indx = indx + 1
       obj%JA(indx) = ii
       obj%idiag(ii) = indx
       A(indx) = A_diag(ii)
     END IF
-    !
+
     DO rindx = IA_csc(ii), IA_csc(ii + 1) - 1
       indx = indx + 1
       obj%JA(indx) = JA_csc(rindx)
       A(indx) = A_csc(rindx)
     END DO
-    !
   END DO
-  !
+
   ! Clean up
-  !
   DEALLOCATE (IA_csr, IA_csc, JA_csr, JA_csc, idiag, A_csr, A_csc, A_diag)
-  !
 END SUBROUTINE obj_GetSymL2
 
 !----------------------------------------------------------------------------
@@ -788,11 +793,7 @@ END SUBROUTINE obj_GetSymL2
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_GetSym1
-INTEGER(I4B) :: ii, jj, nrow, rindx
-REAL(DFP) :: VALUE
-!
 ! Matrix should be square
-!
 symObj%csrOwnership = obj%csrOwnership
 symObj%tDimension = obj%tDimension
 symObj%matrixProp = "SYM"
@@ -801,21 +802,20 @@ IF (ALLOCATED(obj%A)) THEN
   SELECT CASE (from)
   CASE ("U", "u")
     CALL obj_GetSymU1(obj=obj%csr, symobj=symobj%csr, A=obj%A, &
-      & symA=symobj%A)
+                      symA=symobj%A)
   CASE ("L", "l")
     CALL obj_GetSymL1(obj=obj%csr, symobj=symobj%csr, A=obj%A, &
-      & symA=symobj%A)
+                      symA=symobj%A)
   CASE DEFAULT
-    CALL Errormsg(&
-     & msg="No match found for given from = "//from, &
-     & file=__FILE__, &
-     & routine="obj_GetSym1()", &
-     & line=__LINE__, &
-     & unitno=stderr)
+    CALL Errormsg( &
+      msg="No match found for given from = "//from, &
+      file=__FILE__, &
+      routine="obj_GetSym1()", &
+      line=__LINE__, &
+      unitno=stderr)
     STOP
   END SELECT
 END IF
-
 END PROCEDURE obj_GetSym1
 
 !----------------------------------------------------------------------------
@@ -823,11 +823,7 @@ END PROCEDURE obj_GetSym1
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_GetSym2
-INTEGER(I4B) :: ii, jj, nrow, rindx
-REAL(DFP) :: VALUE
-!
 ! Matrix should be square
-!
 obj%matrixProp = "SYM"
 
 IF (ALLOCATED(obj%A)) THEN
@@ -837,12 +833,12 @@ IF (ALLOCATED(obj%A)) THEN
   CASE ("L", "l")
     CALL obj_GetSymL2(obj=obj%csr, A=obj%A)
   CASE DEFAULT
-    CALL Errormsg(&
-     & msg="No match found for given from = "//from, &
-     & file=__FILE__, &
-     & routine="obj_GetSym2()", &
-     & line=__LINE__, &
-     & unitno=stderr)
+    CALL Errormsg( &
+      msg="No match found for given from = "//from, &
+      file=__FILE__, &
+      routine="obj_GetSym2()", &
+      line=__LINE__, &
+      unitno=stderr)
     STOP
   END SELECT
 END IF
@@ -852,4 +848,5 @@ END PROCEDURE obj_GetSym2
 !----------------------------------------------------------------------------
 !
 !----------------------------------------------------------------------------
+
 END SUBMODULE Methods

--- a/src/submodules/CSRSparsity/src/CSRSparsity_Method@SymMethods.F90
+++ b/src/submodules/CSRSparsity/src/CSRSparsity_Method@SymMethods.F90
@@ -20,7 +20,8 @@
 ! summary: Input output related methods
 
 SUBMODULE(CSRSparsity_Method) SymMethods
-USE BaseMethod
+USE ReallocateUtility, ONLY: Reallocate
+USE ErrorHandling, ONLY: Errormsg
 IMPLICIT NONE
 CONTAINS
 
@@ -37,18 +38,19 @@ SUBROUTINE obj_GetSymU1(obj, symobj)
   INTEGER(I4B), ALLOCATABLE :: IA_csr(:), IA_csc(:), JA_csr(:), &
     & JA_csc(:), idiag(:)
   REAL(DFP) :: real_dummy(1)
-  !
-  nnz_parts = GetNNZ(obj, [""])
+  CHARACTER(1), PARAMETER :: from(1) = [" "]
+
+  nnz_parts = GetNNZ(obj=obj, from=from)
   nrow = obj%nrow
   ncol = obj%ncol
   nnzU = nnz_parts(1)
   nnzD = nnz_parts(3)
-  !
+
   CALL Reallocate(JA_csr, nnzU, IA_csr, nrow + 1)
   CALL Reallocate(idiag, nrow)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, nrow
     IA_csr(ii) = indx + 1
     IA_csr(ii + 1) = IA_csr(ii)
@@ -63,9 +65,9 @@ SUBROUTINE obj_GetSymU1(obj, symobj)
       END IF
     END DO
   END DO
-  !
+
   CALL Reallocate(IA_csc, ncol + 1, JA_csc, nnzU)
-  !
+
   CALL csrcsc( &
     & nrow, &
     & 0, &
@@ -76,7 +78,7 @@ SUBROUTINE obj_GetSymU1(obj, symobj)
     & real_dummy, &
     & JA_csc, &
     & IA_csc)
-  !
+
   symobj%nnz = nnz_parts(1) * 2 + nnz_parts(3)
   symobj%ncol = ncol
   symobj%nrow = nrow
@@ -86,12 +88,12 @@ SUBROUTINE obj_GetSymU1(obj, symobj)
   symobj%isDiagStored = .TRUE.
   symobj%idof = obj%idof
   symobj%jdof = obj%jdof
-  !
+
   CALL Reallocate(symobj%IA, nrow + 1, symobj%idiag, nrow)
   CALL Reallocate(symobj%JA, symobj%nnz)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, symobj%nrow
     ar = IA_csr(ii + 1) - IA_csr(ii)
     al = IA_csc(ii + 1) - IA_csr(ii)
@@ -100,32 +102,30 @@ SUBROUTINE obj_GetSymU1(obj, symobj)
     ELSE
       ad = 0
     END IF
-    !
+
     symobj%IA(ii) = indx + 1
     symobj%IA(ii + 1) = symobj%IA(ii) + ar + al + ad
-    !
+
     DO rindx = IA_csc(ii), IA_csc(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csc(rindx)
     END DO
-    !
+
     IF (idiag(ii) .NE. 0) THEN
       indx = indx + 1
       symobj%JA(indx) = obj%JA(idiag(ii))
       symobj%idiag(ii) = indx
     END IF
-    !
+
     DO rindx = IA_csr(ii), IA_csr(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csr(rindx)
     END DO
-    !
+
   END DO
-  !
+
   ! Clean up
-  !
   DEALLOCATE (IA_csr, IA_csc, JA_csr, JA_csc, idiag)
-  !
 END SUBROUTINE obj_GetSymU1
 
 !----------------------------------------------------------------------------
@@ -135,24 +135,25 @@ END SUBROUTINE obj_GetSymU1
 SUBROUTINE obj_GetSymL1(obj, symobj)
   TYPE(CSRSparsity_), INTENT(IN) :: obj
   TYPE(CSRSparsity_), INTENT(INOUT) :: symobj
-  !
+
   INTEGER(I4B) :: nnz_parts(3), ii, jj, rindx, indx, nrow, nnzL, ncol, &
     & nnzD, al, ar, ad
   INTEGER(I4B), ALLOCATABLE :: IA_csr(:), IA_csc(:), JA_csr(:), &
     & JA_csc(:), idiag(:)
   REAL(DFP) :: real_dummy(1)
-  !
-  nnz_parts = GetNNZ(obj, [""])
+  CHARACTER(1), PARAMETER :: from(1) = [" "]
+
+  nnz_parts = GetNNZ(obj=obj, from=from)
   nrow = obj%nrow
   ncol = obj%ncol
   nnzL = nnz_parts(2)
   nnzD = nnz_parts(3)
-  !
+
   CALL Reallocate(JA_csr, nnzL, IA_csr, nrow + 1)
   CALL Reallocate(idiag, nrow)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, nrow
     IA_csr(ii) = indx + 1
     IA_csr(ii + 1) = IA_csr(ii)
@@ -167,9 +168,9 @@ SUBROUTINE obj_GetSymL1(obj, symobj)
       END IF
     END DO
   END DO
-  !
+
   CALL Reallocate(IA_csc, ncol + 1, JA_csc, nnzL)
-  !
+
   CALL csrcsc( &
     & nrow, &
     & 0, &
@@ -180,7 +181,7 @@ SUBROUTINE obj_GetSymL1(obj, symobj)
     & real_dummy, &
     & JA_csc, &
     & IA_csc)
-  !
+
   symobj%nnz = nnzL * 2 + nnzD
   symobj%ncol = ncol
   symobj%nrow = nrow
@@ -190,12 +191,12 @@ SUBROUTINE obj_GetSymL1(obj, symobj)
   symobj%isDiagStored = .TRUE.
   symobj%idof = obj%idof
   symobj%jdof = obj%jdof
-  !
+
   CALL Reallocate(symobj%IA, nrow + 1, symobj%idiag, nrow)
   CALL Reallocate(symobj%JA, symobj%nnz)
-  !
+
   indx = 0
-  !
+
   DO ii = 1, symobj%nrow
     al = IA_csr(ii + 1) - IA_csr(ii)
     ar = IA_csc(ii + 1) - IA_csc(ii)
@@ -204,32 +205,30 @@ SUBROUTINE obj_GetSymL1(obj, symobj)
     ELSE
       ad = 0
     END IF
-    !
+
     symobj%IA(ii) = indx + 1
     symobj%IA(ii + 1) = symobj%IA(ii) + ar + al + ad
-    !
+
     DO rindx = IA_csr(ii), IA_csr(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csr(rindx)
     END DO
-    !
+
     IF (idiag(ii) .NE. 0) THEN
       indx = indx + 1
       symobj%JA(indx) = obj%JA(idiag(ii))
       symobj%idiag(ii) = indx
     END IF
-    !
+
     DO rindx = IA_csc(ii), IA_csc(ii + 1) - 1
       indx = indx + 1
       symobj%JA(indx) = JA_csc(rindx)
     END DO
-    !
+
   END DO
-  !
+
   ! Clean up
-  !
   DEALLOCATE (IA_csr, IA_csc, JA_csr, JA_csc, idiag)
-  !
 END SUBROUTINE obj_GetSymL1
 
 !----------------------------------------------------------------------------
@@ -242,7 +241,7 @@ CASE ("U", "u")
   CALL obj_GetSymU1(obj=obj, symobj=symobj)
 CASE ("L", "l")
   CALL obj_GetSymL1(obj=obj, symobj=symobj)
-CASE default
+CASE DEFAULT
   CALL Errormsg( &
     & msg="No case found for given from = "//from, &
     & file=__FILE__, &
@@ -257,7 +256,6 @@ END PROCEDURE obj_GetSym1
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_GetSym2
-
 END PROCEDURE obj_GetSym2
 
 END SUBMODULE SymMethods


### PR DESCRIPTION
Fix the `BaseType` import typo in `CSRMatrix_SetMethods` and clean up CSR matrix unary/symmetry code to use explicit module imports, aliased procedure calls, and normalized math/default constants. The changes also tighten symmetric CSR sparsity construction by switching to named `GetNNZ` arguments, adding the missing utility imports, and improving consistency in error handling and procedure naming.