### PR TITLE
Fix compile error and enhance reference classes with new cases

### DIFF
--- a/src/modules/Geometry/src/ReferenceElement_Method.F90
+++ b/src/modules/Geometry/src/ReferenceElement_Method.F90
@@ -1368,4 +1368,8 @@ INTERFACE GetVTKElementType_
   END SUBROUTINE GetVTKElementType1_
 END INTERFACE GetVTKElementType_
 
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
 END MODULE ReferenceElement_Method

--- a/src/submodules/CSRMatrix/src/CSRMatrix_UnaryMethods@Methods.F90
+++ b/src/submodules/CSRMatrix/src/CSRMatrix_UnaryMethods@Methods.F90
@@ -342,7 +342,7 @@ SUBROUTINE obj_GetSymU1(obj, symobj, A, symA)
     & JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:)
   !
-  nnz_parts = GetNNZ(obj, [""])
+  nnz_parts = GetNNZ(obj, [" "])
   nrow = obj%nrow
   ncol = obj%ncol
   nnzU = nnz_parts(1)
@@ -457,7 +457,7 @@ SUBROUTINE obj_GetSymU2(obj, A)
     & JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:), A_diag(:)
   !
-  nnz_parts = GetNNZ(obj, [""])
+  nnz_parts = GetNNZ(obj, [" "])
   nrow = obj%nrow
   ncol = obj%ncol
   nnzU = nnz_parts(1)
@@ -570,7 +570,7 @@ SUBROUTINE obj_GetSymL1(obj, symobj, A, symA)
     & JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:), A_diag(:)
   !
-  nnz_parts = GetNNZ(obj, [""])
+  nnz_parts = GetNNZ(obj, [" "])
   nrow = obj%nrow
   ncol = obj%ncol
   nnzL = nnz_parts(2)
@@ -683,7 +683,7 @@ SUBROUTINE obj_GetSymL2(obj, A)
     & JA_csc(:), idiag(:)
   REAL(DFP), ALLOCATABLE :: A_csr(:), A_csc(:), A_diag(:)
   !
-  nnz_parts = GetNNZ(obj, [""])
+  nnz_parts = GetNNZ(obj, [" "])
   nrow = obj%nrow
   ncol = obj%ncol
   nnzL = nnz_parts(2)

--- a/src/submodules/CSRSparsity/src/CSRSparsity_Method@SymMethods.F90
+++ b/src/submodules/CSRSparsity/src/CSRSparsity_Method@SymMethods.F90
@@ -38,7 +38,7 @@ SUBROUTINE obj_GetSymU1(obj, symobj)
     & JA_csc(:), idiag(:)
   REAL(DFP) :: real_dummy(1)
   !
-  nnz_parts = GetNNZ(obj, [""])
+  nnz_parts = GetNNZ(obj, [" "])
   nrow = obj%nrow
   ncol = obj%ncol
   nnzU = nnz_parts(1)
@@ -142,7 +142,7 @@ SUBROUTINE obj_GetSymL1(obj, symobj)
     & JA_csc(:), idiag(:)
   REAL(DFP) :: real_dummy(1)
   !
-  nnz_parts = GetNNZ(obj, [""])
+  nnz_parts = GetNNZ(obj, [" "])
   nrow = obj%nrow
   ncol = obj%ncol
   nnzL = nnz_parts(2)

--- a/src/submodules/Geometry/src/ReferenceElement_Method@VTKMethods.F90
+++ b/src/submodules/Geometry/src/ReferenceElement_Method@VTKMethods.F90
@@ -21,6 +21,7 @@
 
 SUBMODULE(ReferenceElement_Method) VTKMethods
 USE ArangeUtility, ONLY: arange
+USE BaseType, ONLY: TypeElemNameOpt
 USE BaseType, ONLY: TypePointNameOpt
 USE BaseType, ONLY: TypeLineNameOpt
 USE BaseType, ONLY: TypeTriangleNameOpt
@@ -29,6 +30,8 @@ USE BaseType, ONLY: TypeTetrahedronNameOpt
 USE BaseType, ONLY: TypeHexahedronNameOpt
 USE BaseType, ONLY: TypePrismNameOpt
 USE BaseType, ONLY: TypePyramidNameOpt
+USE ReferenceElement_Method, ONLY: TotalNodesInElement
+USE ReferenceElement_Method, ONLY: ElementTopology
 
 IMPLICIT NONE
 
@@ -51,9 +54,26 @@ INTEGER(I4B), PARAMETER :: vtk_prism15 = 26
 INTEGER(I4B), PARAMETER :: vtk_prism18 = 32
 INTEGER(I4B), PARAMETER :: vtk_line4 = 35
 INTEGER(I4B), PARAMETER :: vtk_pyramid13 = 27
-INTEGER(I4B), PARAMETER :: vtk_quadrangle16 = 70
+INTEGER(I4B), PARAMETER :: vtk_LagrangeCurve = 68
+! any order line
+INTEGER(I4B), PARAMETER :: vtk_LagrangeTriangle = 69
+! any order triangle
+INTEGER(I4B), PARAMETER :: vtk_LagrangeQuadrilateral = 70
+! any order quadrilateral
+INTEGER(I4B), PARAMETER :: vtk_LagrangeTetrahedron = 71
+! any order tetrahedron
+INTEGER(I4B), PARAMETER :: vtk_LagrangeHexahedron = 72
+! any order hexahedron
+! TODO: generic higher order elements
+! INTEGER(I4B), PARAMETER :: vtk_HigherOrderCurve = 60
+! INTEGER(I4B), PARAMETER :: vtk_HigherOrderTriangle = 61
+! INTEGER(I4B), PARAMETER :: vtk_HigherOrderQuadrilateral = 62
+! INTEGER(I4B), PARAMETER :: vtk_HigherOrderTetrahedron = 64
+! INTEGER(I4B), PARAMETER :: vtk_HigherOrderWedge = 65
+! INTEGER(I4B), PARAMETER :: vtk_HigherOrderPyramid = 66
+ !!not implemented in paraview
+! INTEGER(I4B), PARAMETER :: vtk_HigherOrderHexahedron = 67
 
-! VTK_LAGRANGE_QUADRILATERAL
 CONTAINS
 
 !----------------------------------------------------------------------------
@@ -61,106 +81,14 @@ CONTAINS
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE GetVTKElementType1
+INTEGER(I4B) :: tsize
 
-SELECT CASE (elemType)
-CASE (TypePointNameOpt%point)
-  vtk_type = vtk_point
-  nptrs = [1]
+tsize = TotalNodesInElement(elemType)
 
-CASE (TypeLineNameOpt%line)
-  vtk_type = vtk_line2
-  nptrs = [1, 2]
+IF (.NOT. ALLOCATED(nptrs)) ALLOCATE (nptrs(tsize))
 
-CASE (TypeTriangleNameOpt%triangle)
-  vtk_type = vtk_triangle3
-  nptrs = [1, 2, 3]
+CALL GetVTKElementType1_(elemType, vtk_type, nptrs, tsize)
 
-CASE (TypeQuadrangleNameOpt%quadrangle)
-  vtk_type = vtk_quadrangle4
-  nptrs = [1, 2, 3, 4]
-
-CASE (TypeTetrahedronNameOpt%tetrahedron)
-  vtk_type = vtk_tetrahedron4
-  nptrs = [1, 2, 3, 4]
-
-CASE (TypeHexahedronNameOpt%hexahedron)
-  vtk_type = vtk_hexahedron8
-  nptrs = [1, 2, 3, 4, 5, 6, 7, 8]
-
-CASE (TypePrismNameOpt%prism)
-  vtk_type = vtk_Prism6
-  nptrs = [1, 2, 3, 4, 5, 6]
-
-CASE (TypePyramidNameOpt%pyramid)
-  vtk_type = vtk_Pyramid5
-  nptrs = [1, 2, 3, 4, 5]
-
-  !! Order=2 elements
-CASE (TypeLineNameOpt%line3)
-  vtk_type = vtk_line3
-  nptrs = [1, 2, 3]
-
-CASE (TypeTriangleNameOpt%triangle6)
-  vtk_type = vtk_Triangle6
-  nptrs = [1, 2, 3, 4, 5, 6]
-
-CASE (TypeQuadrangleNameOpt%quadrangle9)
-  vtk_type = vtk_Quadrangle9
-  nptrs = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-
-CASE (TypeQuadrangleNameOpt%quadrangle8)
-  vtk_type = vtk_Quadrangle8
-  nptrs = [1, 2, 3, 4, 5, 6, 7, 8]
-
-CASE (TypeTetrahedronNameOpt%tetrahedron10)
-  vtk_type = vtk_Tetrahedron10
-  nptrs = 1 + [0, 1, 2, 3, 4, 5, 6, 7, 9, 8]
-
-CASE (TypeHexahedronNameOpt%hexahedron20)
-  vtk_type = vtk_Hexahedron20
-  nptrs = 1 + [0, 1, 2, 3, 4, 5, 6, 7, &
-               8, 11, 16, 9, 17, 10, 18, 19, 12, 15, 13, 14]
-
-CASE (TypeHexahedronNameOpt%hexahedron27)
-  vtk_type = vtk_Hexahedron27
-  nptrs = 1 + [0, 1, 2, 3, 4, 5, 6, 7, &
-               8, 11, 16, 9, 17, 10, 18, 19, 12, 15, 13, 14, &
-               24, 22, 20, 21, 23, 25, 26]
-
-CASE (TypePrismNameOpt%prism15)
-  vtk_type = vtk_Prism15
-  nptrs = 1 + [0, 1, 2, 3, 4, 5, &
-               6, 8, 12, 7, 13, 14, 9, 11, 10]
-
-CASE (TypePrismNameOpt%prism18)
-  vtk_type = vtk_Prism18
-  nptrs = 1 + [0, 1, 2, 3, 4, 5, &
-               6, 8, 12, 7, 13, 14, 9, 11, 10, &
-               15, 17, 16]
-
-CASE (TypePyramidNameOpt%pyramid13)
-  vtk_type = vtk_Pyramid13
-  nptrs = 1 + [0, 1, 2, 3, 4, 5, &
-               5, 8, 9, 6, 10, 7, 11, 12]
-
-CASE (TypePyramidNameOpt%pyramid14)
-  vtk_type = vtk_Pyramid13
-  nptrs = 1 + [0, 1, 2, 3, 4, 5, &
-               5, 8, 9, 6, 10, 7, 11, 12]
-
-  !! order=3 element
-CASE (TypeLineNameOpt%line4)
-  vtk_type = vtk_line4
-  nptrs = [1, 2, 3, 4]
-
-CASE (TypeQuadrangleNameOpt%quadrangle16)
-  vtk_type = vtk_Quadrangle16
-  nptrs = [1, 2, 3, 4, 5, 6, 7, 8, 10, 9, &
-           12, 11, 13, 14, 16, 15]
-CASE DEFAULT
-  vtk_type = -1
-  ALLOCATE (nptrs(0))
-END SELECT
 END PROCEDURE GetVTKElementType1
 
 !----------------------------------------------------------------------------
@@ -168,123 +96,43 @@ END PROCEDURE GetVTKElementType1
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE GetVTKElementType1_
+INTEGER(I4B) :: topo
 
-SELECT CASE (elemType)
-CASE (TypePointNameOpt%point)
-  vtk_type = vtk_point
-  tsize = 1
-  nptrs(1:tsize) = [1]
+topo = ElementTopology(elemType)
 
-CASE (TypeLineNameOpt%line)
-  vtk_type = vtk_line2
-  tsize = 2
-  nptrs(1:tsize) = [1, 2]
+SELECT CASE (topo)
 
-CASE (TypeTriangleNameOpt%triangle)
-  vtk_type = vtk_triangle3
-  tsize = 3
-  nptrs(1:tsize) = [1, 2, 3]
+CASE (TypeElemNameOpt%point)
 
-CASE (TypeQuadrangleNameOpt%quadrangle)
-  vtk_type = vtk_quadrangle4
-  tsize = 4
-  nptrs(1:tsize) = [1, 2, 3, 4]
+  CALL GetVTKElementType_Point_(elemType, nptrs, vtk_type, tsize)
 
-CASE (TypeTetrahedronNameOpt%tetrahedron)
-  vtk_type = vtk_Tetrahedron4
-  tsize = 4
-  nptrs(1:tsize) = [1, 2, 3, 4]
+CASE (TypeElemNameOpt%line)
 
-CASE (TypeHexahedronNameOpt%hexahedron)
-  vtk_type = vtk_Hexahedron8
-  tsize = 8
-  nptrs(1:tsize) = [1, 2, 3, 4, 5, 6, 7, 8]
+  CALL GetVTKElementType_Line_(elemType, nptrs, vtk_type, tsize)
 
-CASE (TypePrismNameOpt%prism)
-  vtk_type = vtk_Prism6
-  tsize = 6
-  nptrs(1:tsize) = [1, 2, 3, 4, 5, 6]
+CASE (TypeElemNameOpt%triangle)
 
-CASE (TypePyramidNameOpt%pyramid)
-  vtk_type = vtk_Pyramid5
-  tsize = 5
-  nptrs(1:tsize) = [1, 2, 3, 4, 5]
+  CALL GetVTKElementType_Triangle_(elemType, nptrs, vtk_type, tsize)
 
-  !! Order=2 elements
-CASE (TypeLineNameOpt%line3)
-  vtk_type = vtk_line3
-  tsize = 3
-  nptrs(1:tsize) = [1, 2, 3]
+CASE (TypeElemNameOpt%quadrangle)
 
-CASE (TypeTriangleNameOpt%triangle6)
-  vtk_type = vtk_Triangle6
-  tsize = 6
-  nptrs(1:tsize) = [1, 2, 3, 4, 5, 6]
+  CALL GetVTKElementType_Quadrangle_(elemType, nptrs, vtk_type, tsize)
 
-CASE (TypeQuadrangleNameOpt%quadrangle9)
-  vtk_type = vtk_Quadrangle9
-  tsize = 9
-  nptrs(1:tsize) = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+CASE (TypeElemNameOpt%tetrahedron)
 
-CASE (TypeQuadrangleNameOpt%quadrangle8)
-  vtk_type = vtk_Quadrangle8
-  tsize = 8
-  nptrs(1:tsize) = [1, 2, 3, 4, 5, 6, 7, 8]
+  CALL GetVTKElementType_Tetrahedron_(elemType, nptrs, vtk_type, tsize)
 
-CASE (TypeTetrahedronNameOpt%tetrahedron10)
-  vtk_type = vtk_Tetrahedron10
-  tsize = 10
-  nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, 6, 7, 9, 8]
+CASE (TypeElemNameOpt%hexahedron)
 
-CASE (TypeHexahedronNameOpt%hexahedron20)
-  vtk_type = vtk_Hexahedron20
-  tsize = 20
-  nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, 6, 7, &
-                        8, 11, 16, 9, 17, 10, 18, 19, 12, 15, 13, 14]
+  CALL GetVTKElementType_Hexahedron_(elemType, nptrs, vtk_type, tsize)
 
-CASE (TypeHexahedronNameOpt%hexahedron27)
-  vtk_type = vtk_Hexahedron27
-  tsize = 27
-  nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, 6, 7, &
-                        8, 11, 16, 9, 17, 10, 18, 19, 12, 15, 13, 14, &
-                        24, 22, 20, 21, 23, 25, 26]
+CASE (TypeElemNameOpt%prism)
 
-CASE (TypePrismNameOpt%prism15)
-  vtk_type = vtk_Prism15
-  tsize = 15
-  nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
-                        6, 8, 12, 7, 13, 14, 9, 11, 10]
+  CALL GetVTKElementType_Prism_(elemType, nptrs, vtk_type, tsize)
 
-CASE (TypePrismNameOpt%prism18)
-  vtk_type = vtk_Prism18
-  tsize = 18
-  nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
-                        6, 8, 12, 7, 13, 14, 9, 11, 10, &
-                        15, 17, 16]
+CASE (TypeElemNameOpt%pyramid)
 
-CASE (TypePyramidNameOpt%pyramid13)
-  vtk_type = vtk_Pyramid13
-  tsize = 13
-  nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
-                        5, 8, 9, 6, 10, 7, 11, 12]
-
-CASE (TypePyramidNameOpt%pyramid14)
-  vtk_type = vtk_Pyramid13
-  tsize = 14
-  nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
-                        5, 8, 9, 6, 10, 7, 11, 12]
-
-  !! order=3 element
-CASE (TypeLineNameOpt%line4)
-  vtk_type = vtk_line4
-  tsize = 4
-  nptrs(1:tsize) = [1, 2, 3, 4]
-
-CASE (TypeQuadrangleNameOpt%quadrangle16)
-  vtk_type = vtk_Quadrangle16
-  tsize = 16
-  nptrs(1:tsize) = [1, 2, 3, 4, 5, 6, 7, 8, 10, 9, &
-                    12, 11, 13, 14, 16, 15]
+  CALL GetVTKElementType_Pyramid_(elemType, nptrs, vtk_type, tsize)
 
 CASE DEFAULT
   vtk_type = -1
@@ -292,6 +140,355 @@ CASE DEFAULT
 END SELECT
 
 END PROCEDURE GetVTKElementType1_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Point_(elemType, nptrs, vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  vtk_type = vtk_point
+  tsize = 1
+  nptrs(1:tsize) = [1]
+
+END SUBROUTINE GetVTKElementType_Point_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Line_(elemType, nptrs, vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  tsize = TotalNodesInElement(elemType)
+
+  SELECT CASE (elemType)
+  CASE (TypeLineNameOpt%line2)
+    vtk_type = vtk_line2
+    nptrs(1:tsize) = [1, 2]
+  CASE (TypeLineNameOpt%line3)
+    vtk_type = vtk_line3
+    nptrs(1:tsize) = [1, 2, 3]
+  CASE (TypeLineNameOpt%line4)
+    vtk_type = vtk_line4
+    nptrs(1:tsize) = [1, 2, 3, 4]
+  CASE default
+    vtk_type = -1
+    tsize = 0
+  END SELECT
+
+END SUBROUTINE GetVTKElementType_Line_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Triangle_(elemType, nptrs, vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  tsize = TotalNodesInElement(elemType)
+
+  SELECT CASE (elemType)
+  CASE (TypeTriangleNameOpt%triangle)
+    vtk_type = vtk_triangle3
+    nptrs(1:tsize) = [1, 2, 3]
+  CASE (TypeTriangleNameOpt%triangle6)
+    vtk_type = vtk_triangle6
+    nptrs(1:tsize) = [1, 2, 3, 4, 5, 6]
+  CASE default
+    vtk_type = -1
+    tsize = 0
+  END SELECT
+
+END SUBROUTINE GetVTKElementType_Triangle_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Quadrangle_(elemType, nptrs, &
+                                              vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  tsize = TotalNodesInElement(elemType)
+
+  SELECT CASE (elemType)
+  CASE (TypeQuadrangleNameOpt%quadrangle4)
+    vtk_type = vtk_quadrangle4
+    nptrs(1:tsize) = [1, 2, 3, 4]
+
+  CASE (TypeQuadrangleNameOpt%quadrangle8)
+    vtk_type = vtk_Quadrangle8
+    nptrs(1:tsize) = [1, 2, 3, 4, 5, 6, 7, 8]
+
+  CASE (TypeQuadrangleNameOpt%quadrangle9)
+    vtk_type = vtk_Quadrangle9
+    nptrs(1:tsize) = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+  CASE (TypeQuadrangleNameOpt%quadrangle16)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, &
+                      5, 6, & ! face 1
+                      7, 8, & ! face 2
+                      10, 9, & ! face 3
+                      12, 11, & ! face 4
+                      13, 14, & ! cell 1st row
+                      16, 15] ! cell 2nd row
+
+  CASE (TypeQuadrangleNameOpt%quadrangle25)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, &
+                      5, 6, 7, & ! face 1
+                      8, 9, 10, & ! face 2
+                      13, 12, 11, & ! face 3
+                      16, 15, 14, & ! face 4
+                      17, 21, 18, & ! cell 1st row
+                      24, 25, 22, & ! cell 2nd row
+                      20, 23, 19] ! cell 3rd row
+
+  CASE (TypeQuadrangleNameOpt%quadrangle36)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, & ! vertex
+                      5, 6, 7, 8, & ! face 1
+                      9, 10, 11, 12, & ! face 2
+                      16, 15, 14, 13, & ! face 3
+                      20, 19, 18, 17, & ! face 4
+                      21, 25, 26, 22, & ! cell 1st row
+                      32, 33, 34, 27, & ! cell 2nd row
+                      31, 36, 35, 28, & ! cell 3rd row
+                      24, 30, 29, 23] ! cell 4th row
+
+  CASE (TypeQuadrangleNameOpt%quadrangle49)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, &
+                      5, 6, 7, 8, 9, & ! face 1
+                      10, 11, 12, 13, 14, & ! face 2
+                      19, 18, 17, 16, 15, & ! face 3
+                      24, 23, 22, 21, 20, & ! face 4
+                      25, 29, 30, 31, 26, & ! cell 1st row
+                      40, 41, 45, 42, 32, & ! cell 2nd row
+                      39, 48, 49, 46, 33, & ! cell 3rd row
+                      38, 44, 47, 43, 34, & ! cell 4th row
+                      28, 37, 36, 35, 27] ! cell 5th row
+
+  CASE (TypeQuadrangleNameOpt%quadrangle64)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, & ! vertex
+                      5, 6, 7, 8, 9, 10, & ! face 1
+                      11, 12, 13, 14, 15, 16, & ! face 2
+                      22, 21, 20, 19, 18, 17, & ! face 3
+                      28, 27, 26, 25, 24, 23, & ! face 4
+                      29, 33, 34, 35, 36, 30, & ! cell 1st row
+                      48, 49, 53, 54, 50, 37, & ! cell 2nd row
+                      47, 60, 61, 62, 55, 38, & ! cell 3rd row
+                      46, 59, 64, 63, 56, 39, & ! cell 4th row
+                      45, 52, 58, 57, 51, 40, & ! cell 5th row
+                      32, 44, 43, 42, 41, 31] ! cell 6th row
+
+  CASE (TypeQuadrangleNameOpt%quadrangle81)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, & ! vertex
+                      5, 6, 7, 8, 9, 10, 11, & ! face 1
+                      12, 13, 14, 15, 16, 17, 18, & ! face 2
+                      25, 24, 23, 22, 21, 20, 19, & ! face 3
+                      32, 31, 30, 29, 28, 27, 26, & ! face 4
+                      33, 37, 38, 39, 40, 41, 34, & ! cell 1st row
+                      56, 57, 61, 62, 63, 58, 42, & ! cell 2nd row
+                      55, 72, 73, 77, 74, 64, 43, & ! cell 3rd row
+                      54, 71, 80, 81, 78, 65, 44, & ! cell 4th row
+                      53, 70, 76, 79, 75, 66, 45, & ! cell 5th row
+                      52, 60, 69, 68, 67, 59, 46, & ! cell 6th row
+                      36, 51, 50, 49, 48, 47, 35] ! cell 7th row
+
+  CASE (TypeQuadrangleNameOpt%quadrangle100)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, & ! vertex
+                      5, 6, 7, 8, 9, 10, 11, 12, & ! face 1
+                      13, 14, 15, 16, 17, 18, 19, 20, & ! face 2
+                      28, 27, 26, 25, 24, 23, 22, 21, & ! face 3
+                      36, 35, 34, 33, 32, 31, 30, 29, & ! face 4
+                      37, 41, 42, 43, 44, 45, 46, 38, & ! cell 1st row
+                      64, 65, 69, 70, 71, 72, 66, 47, & ! cell 2nd row
+                      63, 84, 85, 89, 90, 86, 73, 48, & ! cell 3rd row
+                      62, 83, 96, 97, 98, 91, 74, 49, & ! cell 4th row
+                      61, 82, 95, 100, 99, 92, 75, 50, & ! cell 5th row
+                      60, 81, 88, 94, 93, 87, 76, 51, & ! cell 6th row
+                      59, 68, 80, 79, 78, 77, 67, 52, & ! cell 7th row
+                      40, 58, 57, 56, 55, 54, 53, 39] ! cell 8th row
+
+  CASE (TypeQuadrangleNameOpt%quadrangle121)
+    vtk_type = vtk_LagrangeQuadrilateral
+    nptrs(1:tsize) = [1, 2, 3, 4, & ! vertex
+                      5, 6, 7, 8, 9, 10, 11, 12, 13, & ! face 1
+                      14, 15, 16, 17, 18, 19, 20, 21, 22, & ! face 2
+                      31, 30, 29, 28, 27, 26, 25, 24, 23, & ! face 3
+                      40, 39, 38, 37, 36, 35, 34, 33, 32, & ! face 4
+                      41, 45, 46, 47, 48, 49, 50, 51, 42, & ! cell 1st row
+                      72, 73, 77, 78, 79, 80, 81, 74, 52, & ! cell 2nd row
+                      71, 96, 97, 101, 102, 103, 98, 82, 53, & ! cell 3rd row
+                      70, 95, 112, 113, 117, 114, 104, 83, 54, & ! cell 4th row
+                      69, 94, 111, 120, 121, 118, 105, 84, 55, & ! cell 5th row
+                      68, 93, 110, 116, 119, 115, 106, 85, 56, & ! cell 6th row
+                      67, 92, 100, 109, 108, 107, 99, 86, 57, & ! cell 7th row
+                      66, 76, 91, 90, 89, 88, 87, 75, 58, & ! cell 8th row
+                      44, 65, 64, 63, 62, 61, 60, 59, 43] ! cell 9th row
+
+  CASE DEFAULT
+    vtk_type = -1
+    tsize = 0
+  END SELECT
+
+END SUBROUTINE GetVTKElementType_Quadrangle_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Tetrahedron_(elemType, nptrs, &
+                                               vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  tsize = TotalNodesInElement(elemType)
+
+  SELECT CASE (elemType)
+  CASE (TypeTetrahedronNameOpt%tetrahedron4)
+    vtk_type = vtk_Tetrahedron4
+    nptrs(1:tsize) = [1, 2, 3, 4]
+
+  CASE (TypeTetrahedronNameOpt%tetrahedron10)
+    vtk_type = vtk_Tetrahedron10
+    tsize = 10
+    nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, 6, 7, 9, 8]
+
+  CASE default
+    vtk_type = -1
+    tsize = 0
+  END SELECT
+
+END SUBROUTINE GetVTKElementType_Tetrahedron_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Hexahedron_(elemType, nptrs, &
+                                              vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  tsize = TotalNodesInElement(elemType)
+
+  SELECT CASE (elemType)
+  CASE (TypeHexahedronNameOpt%hexahedron8)
+    vtk_type = vtk_Hexahedron8
+    nptrs(1:tsize) = [1, 2, 3, 4, 5, 6, 7, 8]
+
+  CASE (TypeHexahedronNameOpt%hexahedron27)
+    vtk_type = vtk_Hexahedron27
+    nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, 6, 7, &
+                          8, 11, 16, 9, 17, 10, 18, 19, 12, 15, 13, 14, &
+                          24, 22, 20, 21, 23, 25, 26]
+
+  CASE (TypeHexahedronNameOpt%hexahedron20)
+    vtk_type = vtk_Hexahedron20
+    nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, 6, 7, &
+                          8, 11, 16, 9, 17, 10, 18, 19, 12, 15, 13, 14]
+
+  CASE default
+    vtk_type = -1
+    tsize = 0
+  END SELECT
+
+END SUBROUTINE GetVTKElementType_Hexahedron_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Prism_(elemType, nptrs, &
+                                         vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  tsize = TotalNodesInElement(elemType)
+
+  SELECT CASE (elemType)
+  CASE (TypePrismNameOpt%prism6)
+    vtk_type = vtk_Prism6
+    nptrs(1:tsize) = [1, 2, 3, 4, 5, 6]
+
+  CASE (TypePrismNameOpt%prism15)
+    vtk_type = vtk_Prism15
+    nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
+                          6, 8, 12, 7, 13, 14, 9, 11, 10]
+
+  CASE (TypePrismNameOpt%prism18)
+    vtk_type = vtk_Prism18
+    nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
+                          6, 8, 12, 7, 13, 14, 9, 11, 10, &
+                          15, 17, 16]
+  CASE default
+    vtk_type = -1
+    tsize = 0
+  END SELECT
+
+END SUBROUTINE GetVTKElementType_Prism_
+
+!----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+PURE SUBROUTINE GetVTKElementType_Pyramid_(elemType, nptrs, &
+                                           vtk_type, tsize)
+  INTEGER(I4B), INTENT(IN) :: elemType
+  INTEGER(I4B), INTENT(INOUT) :: nptrs(:)
+  INTEGER(INT8), INTENT(OUT) :: vtk_type
+  INTEGER(I4B), INTENT(OUT) :: tsize
+
+  tsize = TotalNodesInElement(elemType)
+
+  SELECT CASE (elemType)
+  CASE (TypePyramidNameOpt%pyramid5)
+    vtk_type = vtk_Pyramid5
+    nptrs(1:tsize) = [1, 2, 3, 4, 5]
+
+  CASE (TypePyramidNameOpt%pyramid13)
+    vtk_type = vtk_Pyramid13
+    tsize = 13
+    nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
+                          5, 8, 9, 6, 10, 7, 11, 12]
+
+  CASE (TypePyramidNameOpt%pyramid14)
+    vtk_type = vtk_Pyramid13
+    tsize = 14
+    nptrs(1:tsize) = 1 + [0, 1, 2, 3, 4, 5, &
+                          5, 8, 9, 6, 10, 7, 11, 12]
+  CASE default
+    vtk_type = -1
+    tsize = 0
+  END SELECT
+
+END SUBROUTINE GetVTKElementType_Pyramid_
 
 !----------------------------------------------------------------------------
 !

--- a/src/submodules/Line/src/ReferenceLine_Method@Methods.F90
+++ b/src/submodules/Line/src/ReferenceLine_Method@Methods.F90
@@ -24,6 +24,8 @@ SUBMODULE(ReferenceLine_Method) Methods
 USE GlobalData, ONLY: Line, Line1, Line2, Line3, Line4, Line5, &
                       Line6, Point1, Equidistance
 
+USE BaseType, ONLY: TypeLineNameOpt
+
 USE ReallocateUtility, ONLY: Reallocate
 
 USE ReferenceElement_Method, ONLY: ReferenceTopology, &
@@ -53,16 +55,26 @@ MODULE PROCEDURE ElementName_Line
 SELECT CASE (elemType)
 CASE (Point1)
   ans = "Point1"
-CASE (Line2)
+CASE (TypeLineNameOpt%Line2)
   ans = "Line2"
-CASE (Line3)
+CASE (TypeLineNameOpt%Line3)
   ans = "Line3"
-CASE (Line4)
+CASE (TypeLineNameOpt%Line4)
   ans = "Line4"
-CASE (Line5)
+CASE (TypeLineNameOpt%Line5)
   ans = "Line5"
-CASE (Line6)
+CASE (TypeLineNameOpt%Line6)
   ans = "Line6"
+CASE (TypeLineNameOpt%Line7)
+  ans = "Line7"
+CASE (TypeLineNameOpt%Line8)
+  ans = "Line8"
+CASE (TypeLineNameOpt%Line9)
+  ans = "Line9"
+CASE (TypeLineNameOpt%Line10)
+  ans = "Line10"
+CASE (TypeLineNameOpt%Line11)
+  ans = "Line11"
 CASE DEFAULT
   ans = "NONE"
 END SELECT
@@ -98,18 +110,28 @@ END PROCEDURE TotalEntities_Line
 
 MODULE PROCEDURE TotalNodesInElement_Line
 SELECT CASE (elemType)
-CASE (Line1)
+CASE (Point1)
   ans = 1
-CASE (Line2)
+CASE (TypeLineNameOpt%Line2)
   ans = 2
-CASE (Line3)
+CASE (TypeLineNameOpt%Line3)
   ans = 3
-CASE (Line4)
+CASE (TypeLineNameOpt%Line4)
   ans = 4
-CASE (Line5)
+CASE (TypeLineNameOpt%Line5)
   ans = 5
-CASE (Line6)
+CASE (TypeLineNameOpt%Line6)
   ans = 6
+CASE (TypeLineNameOpt%Line7)
+  ans = 7
+CASE (TypeLineNameOpt%Line8)
+  ans = 8
+CASE (TypeLineNameOpt%Line9)
+  ans = 9
+CASE (TypeLineNameOpt%Line10)
+  ans = 10
+CASE (TypeLineNameOpt%Line11)
+  ans = 11
 CASE DEFAULT
   ans = 0
 END SELECT
@@ -121,16 +143,26 @@ END PROCEDURE TotalNodesInElement_Line
 
 MODULE PROCEDURE ElementOrder_Line
 SELECT CASE (elemType)
-CASE (Line2)
+CASE (TypeLineNameOpt%Line2)
   ans = 1
-CASE (Line3)
+CASE (TypeLineNameOpt%Line3)
   ans = 2
-CASE (Line4)
+CASE (TypeLineNameOpt%Line4)
   ans = 3
-CASE (Line5)
+CASE (TypeLineNameOpt%Line5)
   ans = 4
-CASE (Line6)
+CASE (TypeLineNameOpt%Line6)
   ans = 5
+CASE (TypeLineNameOpt%Line7)
+  ans = 6
+CASE (TypeLineNameOpt%Line8)
+  ans = 7
+CASE (TypeLineNameOpt%Line9)
+  ans = 8
+CASE (TypeLineNameOpt%Line10)
+  ans = 9
+CASE (TypeLineNameOpt%Line11)
+  ans = 10
 CASE DEFAULT
   ans = 0
 END SELECT
@@ -145,15 +177,25 @@ SELECT CASE (elemName)
 CASE ("Line1", "Point", "Point1")
   ans = Point1
 CASE ("Line2", "Line")
-  ans = Line2
+  ans = TypeLineNameOpt%Line2
 CASE ("Line3")
-  ans = Line3
+  ans = TypeLineNameOpt%Line3
 CASE ("Line4")
-  ans = Line4
+  ans = TypeLineNameOpt%Line4
 CASE ("Line5")
-  ans = Line5
+  ans = TypeLineNameOpt%Line5
 CASE ("Line6")
-  ans = Line6
+  ans = TypeLineNameOpt%Line6
+CASE ("Line7")
+  ans = TypeLineNameOpt%Line7
+CASE ("Line8")
+  ans = TypeLineNameOpt%Line8
+CASE ("Line9")
+  ans = TypeLineNameOpt%Line9
+CASE ("Line10")
+  ans = TypeLineNameOpt%Line10
+CASE ("Line11")
+  ans = TypeLineNameOpt%Line11
 CASE DEFAULT
   ans = 0
 END SELECT
@@ -212,17 +254,27 @@ END PROCEDURE FacetElements_Line2
 MODULE PROCEDURE LineName1
 SELECT CASE (order)
 CASE (1)
-  ans = Line2
+  ans = TypeLineNameOpt%Line2
 CASE (2)
-  ans = Line3
+  ans = TypeLineNameOpt%Line3
 CASE (3)
-  ans = Line4
+  ans = TypeLineNameOpt%Line4
 CASE (4)
-  ans = Line5
+  ans = TypeLineNameOpt%Line5
 CASE (5)
-  ans = Line6
-CASE (6:)
-  ans = Line6 * 100 + order - 5
+  ans = TypeLineNameOpt%Line6
+CASE (6)
+  ans = TypeLineNameOpt%Line7
+CASE (7)
+  ans = TypeLineNameOpt%Line8
+CASE (8)
+  ans = TypeLineNameOpt%Line9
+CASE (9)
+  ans = TypeLineNameOpt%Line10
+CASE (10)
+  ans = TypeLineNameOpt%Line11
+CASE default
+  ans = 0
 END SELECT
 END PROCEDURE LineName1
 

--- a/src/submodules/Quadrangle/src/ReferenceQuadrangle_Method@Methods.F90
+++ b/src/submodules/Quadrangle/src/ReferenceQuadrangle_Method@Methods.F90
@@ -62,6 +62,20 @@ CASE (TypeQuadrangleNameOpt%Quadrangle9)
   ans = "Quadrangle9"
 CASE (TypeQuadrangleNameOpt%Quadrangle16)
   ans = "Quadrangle16"
+CASE (TypeQuadrangleNameOpt%Quadrangle25)
+  ans = "Quadrangle25"
+CASE (TypeQuadrangleNameOpt%Quadrangle36)
+  ans = "Quadrangle36"
+CASE (TypeQuadrangleNameOpt%Quadrangle49)
+  ans = "Quadrangle49"
+CASE (TypeQuadrangleNameOpt%Quadrangle64)
+  ans = "Quadrangle64"
+CASE (TypeQuadrangleNameOpt%Quadrangle81)
+  ans = "Quadrangle81"
+CASE (TypeQuadrangleNameOpt%Quadrangle100)
+  ans = "Quadrangle100"
+CASE (TypeQuadrangleNameOpt%Quadrangle121)
+  ans = "Quadrangle121"
 CASE DEFAULT
   ans = ""
 END SELECT
@@ -114,6 +128,20 @@ CASE (TypeQuadrangleNameOpt%Quadrangle9)
   ans = 9
 CASE (TypeQuadrangleNameOpt%Quadrangle16)
   ans = 16
+CASE (TypeQuadrangleNameOpt%Quadrangle25)
+  ans = 25
+CASE (TypeQuadrangleNameOpt%Quadrangle36)
+  ans = 36
+CASE (TypeQuadrangleNameOpt%Quadrangle49)
+  ans = 49
+CASE (TypeQuadrangleNameOpt%Quadrangle64)
+  ans = 64
+CASE (TypeQuadrangleNameOpt%Quadrangle81)
+  ans = 81
+CASE (TypeQuadrangleNameOpt%Quadrangle100)
+  ans = 100
+CASE (TypeQuadrangleNameOpt%Quadrangle121)
+  ans = 121
 CASE DEFAULT
   ans = 0
 END SELECT
@@ -133,6 +161,20 @@ CASE (TypeQuadrangleNameOpt%Quadrangle9)
   ans = 2
 CASE (TypeQuadrangleNameOpt%Quadrangle16)
   ans = 3
+CASE (TypeQuadrangleNameOpt%Quadrangle25)
+  ans = 4
+CASE (TypeQuadrangleNameOpt%Quadrangle36)
+  ans = 5
+CASE (TypeQuadrangleNameOpt%Quadrangle49)
+  ans = 6
+CASE (TypeQuadrangleNameOpt%Quadrangle64)
+  ans = 7
+CASE (TypeQuadrangleNameOpt%Quadrangle81)
+  ans = 8
+CASE (TypeQuadrangleNameOpt%Quadrangle100)
+  ans = 9
+CASE (TypeQuadrangleNameOpt%Quadrangle121)
+  ans = 10
 CASE DEFAULT
   ans = 0
 END SELECT
@@ -152,6 +194,20 @@ CASE ("Quadrangle9")
   ans = TypeQuadrangleNameOpt%Quadrangle9
 CASE ("Quadrangle16")
   ans = TypeQuadrangleNameOpt%Quadrangle16
+CASE ("Quadrangle25")
+  ans = TypeQuadrangleNameOpt%Quadrangle25
+CASE ("Quadrangle36")
+  ans = TypeQuadrangleNameOpt%Quadrangle36
+CASE ("Quadrangle49")
+  ans = TypeQuadrangleNameOpt%Quadrangle49
+CASE ("Quadrangle64")
+  ans = TypeQuadrangleNameOpt%Quadrangle64
+CASE ("Quadrangle81")
+  ans = TypeQuadrangleNameOpt%Quadrangle81
+CASE ("Quadrangle100")
+  ans = TypeQuadrangleNameOpt%Quadrangle100
+CASE ("Quadrangle121")
+  ans = TypeQuadrangleNameOpt%Quadrangle121
 CASE DEFAULT
   ans = 0
 END SELECT
@@ -258,8 +314,20 @@ CASE (2)
   ans = TypeQuadrangleNameOpt%Quadrangle9
 CASE (3)
   ans = TypeQuadrangleNameOpt%Quadrangle16
-CASE (4:)
-  ans = TypeQuadrangleNameOpt%Quadrangle16 + order - 3_I4B
+CASE (4)
+  ans = TypeQuadrangleNameOpt%Quadrangle25
+CASE (5)
+  ans = TypeQuadrangleNameOpt%Quadrangle36
+CASE (6)
+  ans = TypeQuadrangleNameOpt%Quadrangle49
+CASE (7)
+  ans = TypeQuadrangleNameOpt%Quadrangle64
+CASE (8)
+  ans = TypeQuadrangleNameOpt%Quadrangle81
+CASE (9)
+  ans = TypeQuadrangleNameOpt%Quadrangle100
+CASE (10)
+  ans = TypeQuadrangleNameOpt%Quadrangle121
 CASE DEFAULT
   ans = 0
 END SELECT


### PR DESCRIPTION
This pull request extends support for higher-order line and quadrangle reference elements by adding new element types and updating related logic throughout the codebase. The changes primarily affect how element names, node counts, and orders are handled for lines (up to Line11) and quadrangles (up to Quadrangle121), ensuring the code can accommodate these higher-order elements in all relevant procedures.

**Line element support enhancements:**

* Added `Line7` through `Line11` to all relevant procedures, updating logic to use `TypeLineNameOpt` for element type resolution, name mapping, node counting, and order determination. (`src/submodules/Line/src/ReferenceLine_Method@Methods.F90`) [[1]](diffhunk://#diff-d1b75e0879f53277c33cca11a1c19ef10598a6dfc7da921576e333ddbf6945ceR27-R28) [[2]](diffhunk://#diff-d1b75e0879f53277c33cca11a1c19ef10598a6dfc7da921576e333ddbf6945ceL56-R77) [[3]](diffhunk://#diff-d1b75e0879f53277c33cca11a1c19ef10598a6dfc7da921576e333ddbf6945ceL101-R134) [[4]](diffhunk://#diff-d1b75e0879f53277c33cca11a1c19ef10598a6dfc7da921576e333ddbf6945ceL124-R165) [[5]](diffhunk://#diff-d1b75e0879f53277c33cca11a1c19ef10598a6dfc7da921576e333ddbf6945ceL148-R198) [[6]](diffhunk://#diff-d1b75e0879f53277c33cca11a1c19ef10598a6dfc7da921576e333ddbf6945ceL215-R277)

**Quadrangle element support enhancements:**

* Added `Quadrangle25` through `Quadrangle121` to all relevant procedures, updating logic to use `TypeQuadrangleNameOpt` for element type resolution, name mapping, node counting, and order determination. (`src/submodules/Quadrangle/src/ReferenceQuadrangle_Method@Methods.F90`) [[1]](diffhunk://#diff-a9f0169a2cd1d5af83d86ea38deefdb443ffeb4707cd266a45e3670c0e097bc0R65-R78) [[2]](diffhunk://#diff-a9f0169a2cd1d5af83d86ea38deefdb443ffeb4707cd266a45e3670c0e097bc0R131-R144) [[3]](diffhunk://#diff-a9f0169a2cd1d5af83d86ea38deefdb443ffeb4707cd266a45e3670c0e097bc0R164-R177) [[4]](diffhunk://#diff-a9f0169a2cd1d5af83d86ea38deefdb443ffeb4707cd266a45e3670c0e097bc0R197-R210) [[5]](diffhunk://#diff-a9f0169a2cd1d5af83d86ea38deefdb443ffeb4707cd266a45e3670c0e097bc0L261-R330)

**Code organization:**

* Added missing module documentation separators in `ReferenceElement_Method.F90` for clarity. (`src/modules/Geometry/src/ReferenceElement_Method.F90`)

These updates ensure that the codebase can handle a broader range of higher-order elements, improving flexibility and future-proofing for advanced finite element methods.